### PR TITLE
1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Compare workspace file to server
-- Auto-diff files on check-out conflict
 - File minification on save/upload
 - More control over which files/folders are synchronized
 
-## 0.10.2 - 2017-12-21
+## 1.0 - 2017-12-
+### Added
+- Integrated VSCode's file comparison tools. File compare can now be used:
+    - via the treeview context menu - right click on a file and compare to server.
+    - when checking out a file - if the current server version and your local copy of a file are different, you will be prompted to view both files in a compare window.
+- Refactored File Check in/out: Now you can manage binary files as well as text files through SPGo.
+### Changed
+- Reduced memory pressure with File checkout.
+- Refactored Http error handling to provide a consistent user experience and DRY up a bunch of code. I'm only 80% happy with the current system, so expect more updates here in the future.
+### Fixed
+- Random testing showed that a publishing type of `None` failed in keeping its promise to not upload your file.
+
+## 0.10.3 - 2017-12-21
 ### Added
 - You will now receive an error messages when attempting to edit or check out a file that another user has already checked out.
-###Fixed
+### Fixed
 - Resolved [This issue from Github](https://github.com/readysitego/spgo/issues/14) - Better handling for folder casing and managing files in root site collections.
 - Resolved [This other issue from Github](https://github.com/readysitego/spgo/issues/16) wherein we handle non-existent folders more gracefully when populating a local workspace.
 
@@ -26,7 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Enhanced support for NTLM authentication.
 - Refactored the command objects and much of the File Service/Gateway code to be more Typescripty.
-###Fixed
+### Fixed
 - Changelog dates were a month off. And you thought you WERE writing SharePoint code in the future!
 - Better bad credential management. Was bad, now better.
 - Resolved [This issue from Github](https://github.com/readysitego/spgo/issues/9) - When an error (or manual cancellation by the user) occurs during workspace configuration, SPGo will no properly handle an empty config file.
@@ -79,7 +89,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [Command] Retrieve the contents of a specified folder from SharePoint
 - [Command] Retrieve the contents of multiple folders from SharePoint (Synchronize)
 - Automatically save|publish|check-in current file on save action
-- Project:
 - Initial project documentation (Changelog.md, Readme.md, LICENCE.txt)
-
-## [Unreleased]: 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # SPGo for Visual Studio Code
 
 ## Overview
-SPGo allows you and your team to develop SharePoint web solutions from your local PC using the power of Visual Studio Code. Build SharePoint sites and customizations source-control first with all of the power of a top-tier IDE. Produce cleaner code, deliver faster.
+SPGo allows you and your team to develop SharePoint web solutions from your local PC using the power of Visual Studio Code. Now you can build SharePoint sites and customizations source-control first with all of the power of a top-tier IDE. Produce cleaner code, deliver faster.
 * Publish files on save
 * Use VSCode compare tools to diff local changes against the server
 * Pull down remote folders to your local workspace
 * No more editors messing with your markup 
 * Keep all project configuration in Source Control for easy team integration
-
-### Feedback
-We love feedback! Please take a minute to complete our 2-question [Survey](https://forms.office.com/Pages/ResponsePage.aspx?id=DZb1uny9ZkKNWQyYu-wakJzz1QojmH9AnvOnKspXAdtUNFBVUVdYRTFQN00zOEFPQkFMT0EyMEpZUC4u)!
+    ### Learn More
+    You can view additional documentation [on our blog.](https://www.sitego.co/blog/?category=SPGo)
+    ### Feedback
+    We love feedback! Please take a minute to complete our 2-question [Survey](https://forms.office.com/Pages/ResponsePage.aspx?id=DZb1uny9ZkKNWQyYu-wakJzz1QojmH9AnvOnKspXAdtUNFBVUVdYRTFQN00zOEFPQkFMT0EyMEpZUC4u)!
 
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -1,27 +1,22 @@
 # SPGo for Visual Studio Code
 
-## Final Preview Build
-We are really excited to announce that this will be our final preview branch! SPGo 1.0 will feature the ability to compare files between your local workspace and SharePoint and then we will be live. Thank you, everyone, for your feedback, useage and encouragement in making SPGo a reality!
-
-## Feedback!
-We love feedback! Please take a minute to complete our 2-question [Survey](https://forms.office.com/Pages/ResponsePage.aspx?id=DZb1uny9ZkKNWQyYu-wakJzz1QojmH9AnvOnKspXAdtUNFBVUVdYRTFQN00zOEFPQkFMT0EyMEpZUC4u)!
-
-## Experimental
-We are looking to better integrate with SharePoint via context menu commands - e.g. Check in/Check out from the source treeview control, set as default Master, Update from server. the UX isn't great, as the menus are pretty static. Would love to hear feedback on it.
-
 ## Overview
 SPGo allows you and your team to develop SharePoint web solutions from your local PC using the power of Visual Studio Code. Build SharePoint sites and customizations source-control first with all of the power of a top-tier IDE. Produce cleaner code, deliver faster.
 * Publish files on save
+* Use VSCode compare tools to diff local changes against the server
 * Pull down remote folders to your local workspace
 * No more editors messing with your markup 
 * Keep all project configuration in Source Control for easy team integration
 
+### Feedback
+We love feedback! Please take a minute to complete our 2-question [Survey](https://forms.office.com/Pages/ResponsePage.aspx?id=DZb1uny9ZkKNWQyYu-wakJzz1QojmH9AnvOnKspXAdtUNFBVUVdYRTFQN00zOEFPQkFMT0EyMEpZUC4u)!
+
+
 ## Features
-* Manage multiple configurations
-    * Configuration data is stored within the project directory and can be stored in source control
+* All of the great code authoring and management features of Visual Studio Code, plus the ability to...
 * Check out files from SharePoint
     * Check out current file using command `>SPGo: Check Out the current file`
-    * Check out current file with the hotkey combo: `Alt+Shift+c`
+    * Check out current file with the hotkey combo: `Alt+Shift+C`
 * Publish files to SharePoint
     * Save|publish|check-in automatically on Save
     * Force publish using command `>SPGo: Publish the current file`
@@ -33,6 +28,8 @@ SPGo allows you and your team to develop SharePoint web solutions from your loca
 * Retrieve the contents of multiple folders from SharePoint (Synchronize)
     * Specify an array of site-relative folders in the `remoteFolders` configuration node
     * Download all subfolders automatically by using command `>SPGo: Populate workspace`
+* Manage multiple configurations
+    * Configuration data is stored within the project directory and can be stored in source control
 
 
 ## Security and Authentication Support
@@ -49,10 +46,11 @@ A note for ADFS Authentication: You will need to add the following JSON node to 
 }
 ```
 
+
 ## Configuration and Getting Started
 To get started using SPGo, press `Ctrl+Shift+p` (Windows) `Cmd+Shift+p` (Mac) or open the Command Pallet and type `>SPGo: Configure Workspace` to bring up the SPGo Configuration Wizard. Upon successful configuration, a new file will be created in the root of your project folder called `spgo.json`. From there, all files and folders created under the `src` folder in your local workspace will be deployed to their corresponding site-relative path your SharePoint site upon save.
 
-## SPGo.json Configuration Files
+### SPGo.json Configuration Files
 If configuration was successful, you should see a file similar to below:
 
 ```json
@@ -62,7 +60,6 @@ If configuration was successful, you should see a file similar to below:
     "publishingScope": "SaveOnly",
 } 
 ```
-
 Additionally you can specify an array of remote folders in a node called `remoteFolders`, which SPGo will recursively downloaded to your local workspace when you issue the Synchronize Files command `SPGo: Populate Workspace`. Note: This WILL overwrite all local files.
 ```json
 {
@@ -80,15 +77,14 @@ Additionally you can specify an array of remote folders in a node called `remote
 ## Use
 SPGo will automatically launch when you run the Configure Workspace command `>SPGo: Configure workspace` or any time the SPGO Configuration file `spgo.json` is detected in the root of the current workspace.
 
-## Roadmap
-* [1.0] - Remote File Compare. Merge updates from the server with your local source
-
 
 ## Issues
 Please submit any issues or feature requests to [https://github.com/ReadySiteGo/SPGo/issues](https://github.com/ReadySiteGo/SPGo/issues) or, better yet, author a pull request.
 
+
 ## Open Source
 This project is offered under the MIT open source license. Collaboration, contribution, and feedback is welcomed and encouraged!
+
 
 ## Thank You
 I want to thank the following developers for inspiration and source packages:
@@ -96,6 +92,7 @@ I want to thank the following developers for inspiration and source packages:
 * [Sergey Sergeev](https://github.com/s-KaiNet) : sp-request, spsave author
 * [Andrew Koltyakov](https://github.com/koltyakov) : sppull author
 * [@pkreipke](https://github.com/pkreipke) + [@lafayetteduarte](https://github.com/lafayetteduarte) : Authentication support
+
 
 ## More about SiteGo
 SiteGo is a SharePoint collaboration platform that enables you to simply and securely collaborate with partners, vendors and users outside your company. You can learn more here: [https://www.sitego.co](https://www.sitego.co).

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-    "preview": true,
     "author": {
         "email": "chris@sitego.co",
         "name": "Chris Hasz",
@@ -32,7 +31,7 @@
         "url": "https://github.com/ReadySiteGo/SPGo.git"
     },
     "engines": {
-        "vscode": "^1.17.0"
+        "vscode": "^1.19.0"
     },
     "categories": [
         "Other"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "Office 365",
         "o365"
     ],
-    "version": "0.10.3",
+    "version": "1.0.0",
     "publisher": "SiteGo",
     "icon": "assets/SiteGoLogo.png",
     "galleryBanner": {
@@ -69,7 +69,11 @@
                 "title": "SPGo: Populate local workspace",
                 "description": "Populate your local workspace from the latest on the server."
             },
-
+            {
+                "command": "spgo.publishWorkspace",
+                "title": "SPGo: Publish local workspace",
+                "description": "Publish your local workspace to the server."
+            },
             {
                 "command": "spgo.publishMajor",
                 "title": "SPGo: Publish a major version of the current file",
@@ -124,7 +128,10 @@
         ],
         "menus": {
             "explorer/context": [
-
+                {
+                    "command": "spgo.compareFileWithServer",
+                    "group": "spgo@0"
+                },
                 {
                     "command": "spgo.publishMajor",
                     "group": "spgo@1"

--- a/src/appManager.ts
+++ b/src/appManager.ts
@@ -4,7 +4,7 @@ import {Credential} from './model/credential';
 import {IAppManager} from './spgo';
 import {IConfig} from './spgo';
 import {ICredential} from './spgo';
-import constants from './constants';
+import {Constants} from './constants';
 import {Logger} from './util/logger';
 import initializeConfiguration from './dao/configurationDao';
 
@@ -16,7 +16,7 @@ export class AppManager implements IAppManager {
     
     constructor() {
         this.credentials = new Credential('','');
-        this.outputChannel = vscode.window.createOutputChannel(constants.OUTPUT_CHANNEL_NAME);
+        this.outputChannel = vscode.window.createOutputChannel(Constants.OUTPUT_CHANNEL_NAME);
         this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 5);
 
         //initialize Configuration file

--- a/src/command/checkOutFile.ts
+++ b/src/command/checkOutFile.ts
@@ -1,28 +1,59 @@
 'use strict';
+import * as os from 'os';
+import * as path from 'path';
 import * as vscode from 'vscode';
 
+
 import {Logger} from '../util/logger';
+import {Constants} from './../constants';
 import {UiHelper} from './../util/uiHelper';
 import {FileHelper} from './../util/fileHelper';
 import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationservice';
 
+export default function checkOutFile(fileUri: vscode.Uri) : Thenable<any> {
 
-export default function checkOutFile(textDocument: vscode.TextDocument) : Thenable<any> {
-
-    if( textDocument.fileName.includes(vscode.window.spgo.config.workspaceRoot)){
-        let fileName : string = FileHelper.getFileName(textDocument.fileName);
+    if( fileUri.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
+        let downloadPath : string = os.tmpdir() + path.sep + Constants.TEMP_FOLDER;
+        let fileName : string = FileHelper.getFileName(fileUri.path);
         let fileService : SPFileService = new SPFileService();
 
-        Logger.outputMessage(`Checking out File:  ${textDocument.fileName}`, vscode.window.spgo.outputChannel);
+        Logger.outputMessage(`Checking out File:  ${fileUri.path}`, vscode.window.spgo.outputChannel);
 
         return UiHelper.showStatusBarProgress(`Checking out File:  ${fileName}`,
-            AuthenticationService.verifyCredentials(vscode.window.spgo, textDocument)
-                .then((textDocument) => fileService.checkoutFile(textDocument))
-                .then(() => {
-                    Logger.outputMessage(`file ${textDocument.fileName} successfully checked out from server.`, vscode.window.spgo.outputChannel);
-                })
+            AuthenticationService.verifyCredentials(vscode.window.spgo, fileUri)
+                .then((filePath) => fileService.checkoutFile(filePath))
+                .then(() => downloadFileAndCompare(fileUri, downloadPath))
                 .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
         );
+
+        
+        function downloadFileAndCompare(localPath : vscode.Uri, downloadPath : any){
+
+            fileService.downloadFileMajorVersion(localPath, downloadPath)
+                .then((dlFileUrl) => {
+                    //open files - a bit messy, but necessary for working with async objects
+                    vscode.workspace.openTextDocument(localPath)
+                        .then((doc1) => {
+                            let remotePath : vscode.Uri = vscode.Uri.parse('file:///' + dlFileUrl[0].SavedToLocalPath);
+                            
+                            vscode.workspace.openTextDocument(remotePath)
+                                .then((doc2) => {
+                                    if(doc1.getText() != doc2.getText()){
+                                        vscode.window.showInformationMessage("The server version of this file appears to be different from your local version. Open both files in a compare window?", Constants.OPTIONS_OPEN)
+                                            .then(result => {
+                                                if( result == Constants.OPTIONS_OPEN){
+                                                    Logger.outputMessage(`localPath:  ${localPath} dlFilrUrl: ${remotePath}`, vscode.window.spgo.outputChannel);
+                                                    vscode.commands.executeCommand('vscode.diff', remotePath, localPath, '(Server)  <=====>  (Local)');
+                                                }
+                                            });
+                                    }
+                                });
+                        },
+                        (err) => {
+                                Logger.outputError(err, vscode.window.spgo.outputChannel);
+                        });
+                })
+        }
     }
 }

--- a/src/command/compareFileWithServer.ts
+++ b/src/command/compareFileWithServer.ts
@@ -1,0 +1,30 @@
+'use strict';
+import * as vscode from 'vscode';
+
+import {Logger} from '../util/logger';
+import {UiHelper} from './../util/uiHelper';
+import {FileHelper} from './../util/fileHelper';
+import {SPFileService} from './../service/spFileService';
+import {AuthenticationService} from './../service/authenticationservice';
+
+export default function compareFileWithServer(localPath : vscode.Uri) : Thenable<any> {
+
+    if( localPath.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
+        let fileName : string = FileHelper.getFileName(localPath.path);
+        let fileService : SPFileService = new SPFileService();
+
+        Logger.outputMessage(`Starting file compare for:  ${fileName}`, vscode.window.spgo.outputChannel);
+        
+        return UiHelper.showStatusBarProgress(`Downloading Server version of:  ${fileName}`,
+            AuthenticationService.verifyCredentials(vscode.window.spgo, localPath)
+                .then((localPath) => fileService.downloadFileMajorVersion(localPath))
+                .then((dlFileUrl) => openFileCompare(localPath, dlFileUrl))
+                .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
+        );
+
+        function openFileCompare(localPath : vscode.Uri, dlFileUrl : string){
+            
+            Logger.outputMessage(`localPath:  ${localPath} dlFilrUrl: ${dlFileUrl}`, vscode.window.spgo.outputChannel);
+        }
+    }
+}

--- a/src/command/compareFileWithServer.ts
+++ b/src/command/compareFileWithServer.ts
@@ -1,7 +1,10 @@
 'use strict';
+import * as os from 'os';
+import * as path from 'path';
 import * as vscode from 'vscode';
 
 import {Logger} from '../util/logger';
+import {Constants} from './../constants';
 import {UiHelper} from './../util/uiHelper';
 import {FileHelper} from './../util/fileHelper';
 import {SPFileService} from './../service/spFileService';
@@ -12,19 +15,22 @@ export default function compareFileWithServer(localPath : vscode.Uri) : Thenable
     if( localPath.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
         let fileName : string = FileHelper.getFileName(localPath.path);
         let fileService : SPFileService = new SPFileService();
+        let downloadPath : string = os.tmpdir() + path.sep + Constants.TEMP_FOLDER;
 
         Logger.outputMessage(`Starting file compare for:  ${fileName}`, vscode.window.spgo.outputChannel);
         
         return UiHelper.showStatusBarProgress(`Downloading Server version of:  ${fileName}`,
             AuthenticationService.verifyCredentials(vscode.window.spgo, localPath)
-                .then((localPath) => fileService.downloadFileMajorVersion(localPath))
+                .then((localPath) => fileService.downloadFileMajorVersion(localPath, downloadPath))
                 .then((dlFileUrl) => openFileCompare(localPath, dlFileUrl))
                 .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
         );
 
-        function openFileCompare(localPath : vscode.Uri, dlFileUrl : string){
-            
-            Logger.outputMessage(`localPath:  ${localPath} dlFilrUrl: ${dlFileUrl}`, vscode.window.spgo.outputChannel);
+        function openFileCompare(localPath : vscode.Uri, dlFileUrl : any){            
+            let remotePath : vscode.Uri = vscode.Uri.parse('file:///' + dlFileUrl[0].SavedToLocalPath);
+            Logger.outputMessage(`localPath:  ${localPath} dlFilrUrl: ${remotePath}`, vscode.window.spgo.outputChannel);
+
+            vscode.commands.executeCommand('vscode.diff', remotePath, localPath, '(Server)  <=====>  (Local)');
         }
     }
 }

--- a/src/command/configureWorkspace.ts
+++ b/src/command/configureWorkspace.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs-extra';
 import * as vscode from 'vscode';
 import {Logger} from '../util/logger';
 
-import Constants from './../constants';
+import {Constants} from './../constants';
 import initializeConfiguration from './../dao/configurationDao';
 
 export default function configureWorkspace() {

--- a/src/command/discardCheckOut.ts
+++ b/src/command/discardCheckOut.ts
@@ -7,19 +7,19 @@ import {FileHelper} from './../util/fileHelper';
 import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationservice';
 
-export default function discardCheckOut(textDocument: vscode.TextDocument) : Thenable<any> {
+export default function discardCheckOut(fileUri: vscode.Uri) : Thenable<any> {
 
-    if( textDocument.fileName.includes(vscode.window.spgo.config.workspaceRoot)){
-        let fileName : string = FileHelper.getFileName(textDocument.fileName);
+    if( fileUri.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
+        let fileName : string = FileHelper.getFileName(fileUri.path);
         let fileService : SPFileService = new SPFileService();
 
-        Logger.outputMessage(`Discarding Check out for File:  ${textDocument.fileName}`, vscode.window.spgo.outputChannel);
+        Logger.outputMessage(`Discarding Check out for File:  ${fileUri.path}`, vscode.window.spgo.outputChannel);
         
         return UiHelper.showStatusBarProgress(`Discarding Check out for:  ${fileName}`,
-            AuthenticationService.verifyCredentials(vscode.window.spgo, textDocument)
-                .then((textDocument) => fileService.undoFileCheckout(textDocument))
+            AuthenticationService.verifyCredentials(vscode.window.spgo, fileUri)
+                .then((filePath) => fileService.undoFileCheckout(filePath))
                 .then(() => {
-                    Logger.outputMessage(`Discard check-out successful for file ${textDocument.fileName}.`, vscode.window.spgo.outputChannel);
+                    Logger.outputMessage(`Discard check-out successful for file ${fileUri.path}.`, vscode.window.spgo.outputChannel);
                 })
                 .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
         );

--- a/src/command/publishFile.ts
+++ b/src/command/publishFile.ts
@@ -2,46 +2,27 @@
 import * as vscode from 'vscode';
 
 import {Logger} from '../util/logger';
-import Constants from './../constants';
 import {UiHelper} from './../util/uiHelper';
 import {FileHelper} from './../util/fileHelper';
 import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationservice';
 
 
-export default function publishFile(textDocument: vscode.TextDocument, publishingScope? : string) : Thenable<any> { //, context: vscode.ExtensionContext, publishingScope? : string) : Thenable<any> {
+export default function publishFile(fileUri: vscode.Uri, publishingScope? : string) : Thenable<any> {
 
-    if( textDocument.fileName.includes(vscode.window.spgo.config.workspaceRoot)){
-        let fileName : string = FileHelper.getFileName(textDocument.fileName);
+    if( fileUri.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
+        let fileName : string = FileHelper.getFileName(fileUri.path);
         let fileService : SPFileService = new SPFileService();
-        
-        //ToDo: This is hacky - clean this up.
-        if( publishingScope === Constants.PUBLISHING_MAJOR){
-            Logger.outputMessage(`Publishing major file version:  ${textDocument.fileName}`, vscode.window.spgo.outputChannel);
-         
-            return UiHelper.showStatusBarProgress(`Publishing major file version:  ${fileName}`,
-                AuthenticationService.verifyCredentials(vscode.window.spgo, textDocument)
-                    .then((textDocument) => fileService.publishMajorFileVersion(textDocument))
-                    .then(function(){
-                        Logger.outputMessage('File publish complete.', vscode.window.spgo.outputChannel);
-                    })
-                    .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
-            );
-        }
-        else if( publishingScope === Constants.PUBLISHING_MINOR){
-            Logger.outputMessage(`Publishing minor file version:  ${textDocument.fileName}`, vscode.window.spgo.outputChannel);
 
-            return UiHelper.showStatusBarProgress(`Publishing minor file version:  ${fileName}`,
-                AuthenticationService.verifyCredentials(vscode.window.spgo, textDocument)
-                    .then((textDocument) => fileService.publishMinorFileVersion(textDocument))
-                    .then(function(){
-                        Logger.outputMessage('File publish complete.', vscode.window.spgo.outputChannel);
-                    })
-                    .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
-            );
-        }
+        Logger.outputMessage(`Publishing major file version:  ${fileUri.path}`, vscode.window.spgo.outputChannel);
+        
+        return UiHelper.showStatusBarProgress(`Publishing major file version:  ${fileName}`,
+            AuthenticationService.verifyCredentials(vscode.window.spgo, fileUri)
+                .then((fileUri) => fileService.uploadFileToServer(fileUri, publishingScope))
+                .then(function(){
+                    Logger.outputMessage('File publish complete.', vscode.window.spgo.outputChannel);
+                })
+                .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
+        );
     }
 }
-
-
-//✔

--- a/src/command/saveFile.ts
+++ b/src/command/saveFile.ts
@@ -17,7 +17,7 @@ export default function saveFile(textDocument: vscode.TextDocument) : Thenable<a
 
         return UiHelper.showStatusBarProgress(`Saving file:  ${fileName}`,
             AuthenticationService.verifyCredentials(vscode.window.spgo, textDocument)
-                .then((textDocument) => fileService.uploadFileToServer(textDocument))//() => fileService.uploadFileToServer)//   
+                .then((textDocument) => fileService.uploadFileToServer(textDocument))  
                 .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
         );
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,9 @@
 'use strict';
 
-const constants = {
+export const Constants = {
     CONFIG_FILE_NAME : 'SPGo.json',
     OUTPUT_CHANNEL_NAME: 'SPGo',
+
     PUBLISHING_MAJOR : 'Major',
     PUBLISHING_MINOR : 'Minor',
     PUBLISHING_SAVEONLY : 'SaveOnly',
@@ -11,6 +12,11 @@ const constants = {
     SECURITY_DIGEST : 'Digest',
     SECURITY_NTLM : 'NTLM',
     SECURITY_FORMS : 'Forms',
-    SECURITY_ADFS : 'ADFS'
+    SECURITY_ADFS : 'ADFS',
+
+    TEMP_FOLDER : 'SPGo',
+
+    OPTIONS_OPEN : 'Open'
+
+    //✔
 };
-export default constants;

--- a/src/dao/configurationDao.ts
+++ b/src/dao/configurationDao.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import { IConfig } from './../spgo';
 import {IAppManager} from './../spgo';
 import {Logger} from '../util/logger';
-import Constants from './../constants';
+import {Constants} from './../constants';
 
 export default function initializeConfiguration(appManager?: IAppManager): Promise<IConfig> {
 	return new Promise(function (resolve, reject) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@ import checkOutFile from './command/checkOutFile';
 import publishFile from './command/publishFile';
 import saveFile from './command/saveFile';
 import getCurrentFileInformation from './command/getCurrentFileInformation';
-import Constants from './constants';
+import {Constants} from './constants';
 
 export function activate(context: vscode.ExtensionContext): any {
 
@@ -30,15 +30,14 @@ export function activate(context: vscode.ExtensionContext): any {
     //Check out the current file.
     context.subscriptions.push(vscode.commands.registerCommand('spgo.checkOutFile', (selectedResource?: vscode.Uri) => {
         if (selectedResource && selectedResource.path) {
-            vscode.workspace.openTextDocument(selectedResource)
-                .then(doc => checkOutFile(doc));
+            checkOutFile(selectedResource);
         } 
         else {
-            checkOutFile(vscode.window.activeTextEditor.document);
+            checkOutFile(vscode.window.activeTextEditor.document.uri);
         }
     }));
 
-    //Compare the selected file with it's version on the server.
+    //Compare the selected file with it's latest version on the server.
     context.subscriptions.push(vscode.commands.registerCommand('spgo.compareFileWithServer', (selectedResource?: vscode.Uri) => {
         if (selectedResource && selectedResource.path) {
             compareFileWithServer(selectedResource);
@@ -56,10 +55,9 @@ export function activate(context: vscode.ExtensionContext): any {
     //Discard the checkout of the current file.
     context.subscriptions.push(vscode.commands.registerCommand('spgo.discardCheckOut', (selectedResource?: vscode.Uri) => {
         if (selectedResource && selectedResource.path) {
-            vscode.workspace.openTextDocument(selectedResource)
-                .then(doc => discardCheckOut(doc));
+            discardCheckOut(selectedResource)
         } else {
-            discardCheckOut(vscode.window.activeTextEditor.document);
+            discardCheckOut(vscode.window.activeTextEditor.document.uri);
         }
     }));
 
@@ -76,22 +74,20 @@ export function activate(context: vscode.ExtensionContext): any {
     //Publish the current file to the server.
     context.subscriptions.push(vscode.commands.registerCommand('spgo.publishMajor', (selectedResource?: vscode.Uri) => {
         if (selectedResource && selectedResource.path) {
-            vscode.workspace.openTextDocument(selectedResource)
-                .then(doc => publishFile(doc, Constants.PUBLISHING_MAJOR));
+            publishFile(selectedResource, Constants.PUBLISHING_MAJOR)
         } 
         else {
-            publishFile(vscode.window.activeTextEditor.document, Constants.PUBLISHING_MAJOR);
+            publishFile(vscode.window.activeTextEditor.document.uri, Constants.PUBLISHING_MAJOR);
         }
     }));
 
     //Publish the current file to the server.
     context.subscriptions.push(vscode.commands.registerCommand('spgo.publishMinor', (selectedResource?: vscode.Uri) => {
         if (selectedResource && selectedResource.path) {
-            vscode.workspace.openTextDocument(selectedResource)
-                .then(doc => publishFile(doc, Constants.PUBLISHING_MINOR));
+            publishFile(selectedResource, Constants.PUBLISHING_MINOR)
         } 
         else {
-            publishFile(vscode.window.activeTextEditor.document, Constants.PUBLISHING_MINOR);
+            publishFile(vscode.window.activeTextEditor.document.uri, Constants.PUBLISHING_MINOR);
         }
     }));
 
@@ -109,8 +105,8 @@ export function activate(context: vscode.ExtensionContext): any {
     context.subscriptions.push(vscode.workspace.onDidSaveTextDocument((textDocument: vscode.TextDocument) => {
         if (vscode.window.spgo.config) {
             //is the file in the source folder? Save to the server.
-            if(textDocument.fileName.includes(vscode.window.spgo.config.workspaceRoot)){
-                saveFile(textDocument);// , context);
+            if(textDocument.fileName.includes(vscode.window.spgo.config.workspaceRoot) && Constants.PUBLISHING_NONE != vscode.window.spgo.config.publishingScope){
+                saveFile(textDocument);
             }
             //is this an update to the config? Reload the config.
             else if(textDocument.fileName.endsWith(path.sep + Constants.CONFIG_FILE_NAME)){
@@ -131,12 +127,15 @@ export function activate(context: vscode.ExtensionContext): any {
             getCurrentFileInformation(textDocument);
         }
     }));
-
-
 }
 
 // this method is called when your extension is deactivated
 export function deactivate() {
     // Extension activated.
     Logger.outputMessage('SPGo deactivated.', vscode.window.spgo.outputChannel);
+    
+    //TODO:Should we clean temp files?
+    // if (vscode.window.spgo.config.cleanTempFolderOnExit){
+
+    // }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { AppManager } from './appManager';
 import * as path from 'path';
 
 
+import compareFileWithServer from './command/compareFileWithServer';
 import {Logger} from './util/logger';
 import configureWorkspace from './command/configureWorkspace';
 import initializeConfiguration from './dao/configurationDao';
@@ -36,6 +37,15 @@ export function activate(context: vscode.ExtensionContext): any {
             checkOutFile(vscode.window.activeTextEditor.document);
         }
     }));
+
+    //Compare the selected file with it's version on the server.
+    context.subscriptions.push(vscode.commands.registerCommand('spgo.compareFileWithServer', (selectedResource?: vscode.Uri) => {
+        if (selectedResource && selectedResource.path) {
+            compareFileWithServer(selectedResource);
+        } else {
+            compareFileWithServer(vscode.window.activeTextEditor.document.uri);
+        }
+    }));
     
     //Create the base configuration for this SharePoint workspace
     context.subscriptions.push(vscode.commands.registerCommand('spgo.configureWorkspace', () => {
@@ -43,7 +53,7 @@ export function activate(context: vscode.ExtensionContext): any {
         configureWorkspace();
     }));
 
-    //Create the base configuration for this SharePoint workspace
+    //Discard the checkout of the current file.
     context.subscriptions.push(vscode.commands.registerCommand('spgo.discardCheckOut', (selectedResource?: vscode.Uri) => {
         if (selectedResource && selectedResource.path) {
             vscode.workspace.openTextDocument(selectedResource)

--- a/src/util/errorHelper.ts
+++ b/src/util/errorHelper.ts
@@ -1,0 +1,58 @@
+'use strict';
+import * as vscode from 'vscode';
+
+import {IError} from './../spgo';
+import {Logger} from '../util/logger';
+
+export class ErrorHelper{
+
+    static handleHttpError(err, reject){
+        //HACK: this is sorta hacky- Detect if this error was due to credentials
+        if(err.message && err.message.indexOf('wst:FailedAuthentication') > 0){
+            vscode.window.spgo.credential = null;
+            let error : IError ={
+                message : 'Invalid user credentials. Please reset your credentials via the command menu and try again.' 
+            };
+            Logger.outputError(error, vscode.window.spgo.outputChannel);
+        }
+        //otherwise something else happened.
+        else{
+            if(err.message && err.message.value){
+                Logger.showError(err.message.value, err);
+            }
+            // log sharepoint errors
+            else if(err.error && err.error.error ){
+                Logger.showError(err.error.error.message.value, err);
+            }
+            else{
+                Logger.outputError(err, vscode.window.spgo.outputChannel);
+            }
+        }
+        reject(err);
+    }
+
+    static handleHttpErrorSilently(err, reject){
+        //HACK: this is sorta hacky- Detect if this error was due to credentials
+        if(err.message && err.message.indexOf('wst:FailedAuthentication') > 0){
+            vscode.window.spgo.credential = null;
+            let error : IError ={
+                message : 'Invalid user credentials. Please reset your credentials via the command menu and try again.' 
+            };
+            Logger.outputError(error, vscode.window.spgo.outputChannel);
+        }
+        //otherwise something else happened.
+        else{
+            if(err.message && err.message.value){
+                Logger.outputError(err.message.value, err);
+            }
+            // log sharepoint errors
+            else if(err.error && err.error.error ){
+                Logger.outputError(err.error.error.message.value, err);
+            }
+            else{
+                Logger.outputError(err, vscode.window.spgo.outputChannel);
+            }
+        }
+        reject(err);
+    }
+}

--- a/src/util/fileHelper.ts
+++ b/src/util/fileHelper.ts
@@ -1,8 +1,14 @@
 'use strict';
 import * as path from 'path';
+import * as vscode from 'vscode';
 
 export class FileHelper{
     static getFileName(filePath) : string{
         return filePath.substring(filePath.lastIndexOf(path.sep) + 1);
+    }
+
+    static getFolderFromPath(filePath) : string{
+        let relativeFilePath = filePath.split(vscode.window.spgo.config.workspaceRoot + path.sep)[1].toString();
+        return relativeFilePath.substring(0, relativeFilePath.lastIndexOf(path.sep));
     }
 }

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -29,13 +29,6 @@ export class Logger {
         outputChannel.appendLine(message);
     }
 
-    // static outputMessage(error: SPGo.IError, outputChannel?: vscode.OutputChannel) {
-    //     if(error && error.message){
-    //         outputChannel = outputChannel || vscode.window.spgo.outputChannel;
-    //         outputChannel.appendLine(error.message);
-    //     }
-    // };
-
     static outputWarning(message: string, outputChannel?: vscode.OutputChannel) {
         outputChannel = outputChannel || vscode.window.spgo.outputChannel;
         outputChannel.appendLine(Colors.yellow(message));

--- a/src/util/requestHelper.ts
+++ b/src/util/requestHelper.ts
@@ -8,7 +8,7 @@ import {
   } from 'node-sp-auth';
 
 import {IAppManager} from './../spgo';
-import Constants from './../constants';
+import {Constants} from './../constants';
 
 export class RequestHelper {
 

--- a/src/util/uiHelper.ts
+++ b/src/util/uiHelper.ts
@@ -11,15 +11,16 @@ export class UiHelper{
     
         //p.report({message: 'Start working...' });
         return vscode.window.withProgress(options, 
-            () => {//p => {
-                return new Promise((resolve, reject) => {
-                    action.then(function(){
-                        resolve();
-                    })
-                    .catch(function(err){
-                        reject(err);
-                    });
-                });
+            async () => {//p => {
+                // return new Promise((resolve, reject) => {
+                //     action.then(function(){
+                //         resolve();
+                //     })
+                //     .catch(function(err){
+                //         reject(err);
+                //     });
+                // });
+                return action;
             }
         );
     }

--- a/src/util/urlHelper.ts
+++ b/src/util/urlHelper.ts
@@ -12,7 +12,7 @@ export class UrlHelper{
         let remoteFileName = relativeFilePath.substring(relativeFilePath.lastIndexOf(path.sep)+1);
         let remoteFileUrl = UrlHelper.formatFolder(remoteFolder) + remoteFileName; 
     
-        return Uri.parse(vscode.window.spgo.config.sharePointSiteUrl + remoteFileUrl);
+        return Uri.parse(this.removeTrailingSlash(vscode.window.spgo.config.sharePointSiteUrl) + remoteFileUrl);
     }
     // properly append leading and trailing '/'s to a folder path.
     public static formatFolder(path : string) : string {


### PR DESCRIPTION
## 1.0 - 2017-12-31
### Added
- Integrated VSCode's file comparison tools. File compare can now be used:
    - via the treeview context menu - right click on a file and compare to server.
    - when checking out a file - if the current server version and your local copy of a file are different, you will be prompted to view both files in a compare window.
- Refactored File Check in/out: Now you can manage binary files as well as text files through SPGo.
### Changed
- Reduced memory pressure with File checkout.
- Refactored Http error handling to provide a consistent user experience and DRY up a bunch of code. I'm only 80% happy with the current system, so expect more updates here in the future.
### Fixed
- Random testing showed that a publishing type of `None` failed in keeping its promise to not upload your file.