### PR TITLE
Fixed file publishing with 'SaveOnly' publishing type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - File minification on save/upload
 - More control over which files/folders are synchronized
+- Ability to specify a comment when publishing a file.
 
-## 1.0 - 2017-12-
+## 1.0.1 - 2018-1-3
+### Fixed
+- [This issue from Github](https://github.com/readysitego/spgo/issues/19) which prevented file synchronization on save when users selected "SaveOnly" as the publishing scope.
+
+## 1.0 - 2017-12-31
 ### Added
 - Integrated VSCode's file comparison tools. File compare can now be used:
     - via the treeview context menu - right click on a file and compare to server.

--- a/README.md
+++ b/README.md
@@ -33,21 +33,6 @@ SPGo allows you and your team to develop SharePoint web solutions from your loca
     * Configuration data is stored within the project directory and can be stored in source control
 
 
-## Security and Authentication Support
-Credentials are stored in VSCode memory only. SPGo will only ask you for credentials the first time you sync with SharePoint each session. SPGo currently supports the following authentication modes:
-* Digest (Office365)
-* NTLM (most on-premise installations)
-* NTLM + wwwAuth
-* ADFS
-A note for ADFS Authentication: You will need to add the following JSON node to the root of your your SPGo.json file:
-```json
-"authenticationDetails": {
-    "relayingParty": "[relaying party]",
-    "adfsUrl": "[ADFS Url]"
-}
-```
-
-
 ## Configuration and Getting Started
 To get started using SPGo, press `Ctrl+Shift+p` (Windows) `Cmd+Shift+p` (Mac) or open the Command Pallet and type `>SPGo: Configure Workspace` to bring up the SPGo Configuration Wizard. Upon successful configuration, a new file will be created in the root of your project folder called `spgo.json`. From there, all files and folders created under the `src` folder in your local workspace will be deployed to their corresponding site-relative path your SharePoint site upon save.
 
@@ -78,6 +63,19 @@ Additionally you can specify an array of remote folders in a node called `remote
 ## Use
 SPGo will automatically launch when you run the Configure Workspace command `>SPGo: Configure workspace` or any time the SPGO Configuration file `spgo.json` is detected in the root of the current workspace.
 
+## Security and Authentication Support
+Credentials are stored in VSCode memory only. SPGo will only ask you for credentials the first time you sync with SharePoint each session. SPGo currently supports the following authentication modes:
+* Digest (Office365)
+* NTLM (most on-premise installations)
+* NTLM + wwwAuth
+* ADFS
+A note for ADFS Authentication: You will need to add the following JSON node to the root of your your SPGo.json file:
+```json
+"authenticationDetails": {
+    "relayingParty": "[relaying party]",
+    "adfsUrl": "[ADFS Url]"
+}
+```
 
 ## Issues
 Please submit any issues or feature requests to [https://github.com/ReadySiteGo/SPGo/issues](https://github.com/ReadySiteGo/SPGo/issues) or, better yet, author a pull request.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "Office 365",
         "o365"
     ],
-    "version": "1.0.0",
+    "version": "1.0.1",
     "publisher": "SiteGo",
     "icon": "assets/SiteGoLogo.png",
     "galleryBanner": {

--- a/src/command/saveFile.ts
+++ b/src/command/saveFile.ts
@@ -7,17 +7,17 @@ import {FileHelper} from './../util/fileHelper';
 import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationservice';
 
-export default function saveFile(textDocument: vscode.TextDocument) : Thenable<any> { 
+export default function saveFile(fileUri: vscode.Uri) : Thenable<any> { 
 
-    if( textDocument.fileName.includes(vscode.window.spgo.config.workspaceRoot)){
-        let fileName : string = FileHelper.getFileName(textDocument.fileName);
+    if( fileUri.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
+        let fileName : string = FileHelper.getFileName(fileUri.path);
         let fileService : SPFileService = new SPFileService();
         
-        Logger.outputMessage(`Saving file:  ${textDocument.fileName}`, vscode.window.spgo.outputChannel);
+        Logger.outputMessage(`Saving file:  ${fileUri.path}`, vscode.window.spgo.outputChannel);
 
         return UiHelper.showStatusBarProgress(`Saving file:  ${fileName}`,
-            AuthenticationService.verifyCredentials(vscode.window.spgo, textDocument)
-                .then((textDocument) => fileService.uploadFileToServer(textDocument))  
+            AuthenticationService.verifyCredentials(vscode.window.spgo, fileUri)
+                .then((fileUri) => fileService.uploadFileToServer(fileUri))  
                 .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
         );
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,7 +106,7 @@ export function activate(context: vscode.ExtensionContext): any {
         if (vscode.window.spgo.config) {
             //is the file in the source folder? Save to the server.
             if(textDocument.fileName.includes(vscode.window.spgo.config.workspaceRoot) && Constants.PUBLISHING_NONE != vscode.window.spgo.config.publishingScope){
-                saveFile(textDocument);
+                saveFile(textDocument.uri);
             }
             //is this an update to the config? Reload the config.
             else if(textDocument.fileName.endsWith(path.sep + Constants.CONFIG_FILE_NAME)){


### PR DESCRIPTION
## 1.0.1 - 2018-1-3
### Fixed
- [This issue from Github](https://github.com/readysitego/spgo/issues/19) which prevented file synchronization on save when users selected "SaveOnly" as the publishing scope.
