### PR TITLE
Added support for private Office 365 clouds, resolved a few bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Glob support for retrieving files (e.g. /SiteAssets/*.*, /SiteAssets/*.css)
 - Support for German, Chinese Office 365 datacenters
 
+## 1.2.1 - 2018-2-26
+### Added
+- SPGo now supports Germany, China, and the US Government's private Office 365 deployments! Not so private now, huh?!?
+### Fixed
+- Resolved a visual issue where a glob pattern matching 0 items would cause the progress spinner to spin endlessly.
+- Resolved a number of dependency errors and version incompatibilities between SPGo, TypeScript, VSCode and various Typings.
+
 ## 1.2.0 - 2018-2-23
 ### Added
 - Glob file management for uploads using the `SPGo: Publish local workspace` command.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ Features
     * Specify a glob pattern array of site-relative folders in the `remoteFolders` configuration node (See **Additional Configuration Options** below)
     * Download all subfolders automatically by using command `>SPGo: Populate workspace`
 * Glob Support
-    * All bulk download and upload functionality supports Glob formatting.
-    * note: individual file wildcard support for bulk downloads is still in progress. `>SPGo: Publish local workspace` supports all Glob patterns.
+    * All bulk download and upload functionality supports Glob formatting
+    * note: individual file wildcard support for bulk downloads is still in progress. `>SPGo: Publish local workspace` supports all Glob patterns
 * Manage multiple configurations
     * Configuration data is stored within the project directory and can be stored in source control
+* Global Access
+    * Support for Germany, China, and the US Government's private Office 365 deployments
 
 
 Configuration and Getting Started

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "spgo",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -57,12 +57,14 @@
             "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw=="
         },
         "@types/request": {
-            "version": "0.0.31",
-            "resolved": "https://registry.npmjs.org/@types/request/-/request-0.0.31.tgz",
-            "integrity": "sha1-6ed2YfdsWWpv0O26YiAFZnFxuus=",
+            "version": "2.47.0",
+            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.0.tgz",
+            "integrity": "sha512-/KXM5oev+nNCLIgBjkwbk8VqxmzI56woD4VUxn95O+YeQ8hJzcSmIZ1IN3WexiqBb6srzDo2bdMbsXxgXNkz5Q==",
             "requires": {
+                "@types/caseless": "0.12.1",
                 "@types/form-data": "2.2.1",
-                "@types/node": "6.0.101"
+                "@types/node": "6.0.101",
+                "@types/tough-cookie": "2.3.2"
             }
         },
         "@types/request-promise": {
@@ -71,7 +73,7 @@
             "integrity": "sha512-qlx6COxSTdSFHY9oX9v2zL1I05hgz5lwqYiXa2SFL2nDxAiG5KK8rnllLBH7k6OqzS3Ck0bWbxlGVdrZhS6oNw==",
             "requires": {
                 "@types/bluebird": "3.5.20",
-                "@types/request": "0.0.31"
+                "@types/request": "2.47.0"
             }
         },
         "@types/tough-cookie": {
@@ -85,7 +87,7 @@
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
                 "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
+                "fast-deep-equal": "1.1.0",
                 "fast-json-stable-stringify": "2.0.0",
                 "json-schema-traverse": "0.3.1"
             }
@@ -705,9 +707,9 @@
             }
         },
         "fast-deep-equal": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-            "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
         },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
@@ -1616,9 +1618,9 @@
             "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "inquirer": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-4.0.2.tgz",
-            "integrity": "sha512-+f3qDNeZpkhFJ61NBA9jXDrGGhoQuqfEum9A681c9oHoIbGgVqjogKynjB/vNVP+nVu9w3FbFQ35c0ibU0MaIQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.1.0.tgz",
+            "integrity": "sha512-kn7N70US1MSZHZHSGJLiZ7iCwwncc7b0gc68YtlX29OjI3Mp0tSVV+snVXpZ1G+ONS3Ac9zd1m6hve2ibLDYfA==",
             "requires": {
                 "ansi-escapes": "3.0.0",
                 "chalk": "2.3.1",
@@ -1629,8 +1631,7 @@
                 "lodash": "4.17.5",
                 "mute-stream": "0.0.7",
                 "run-async": "2.3.0",
-                "rx-lite": "4.0.8",
-                "rx-lite-aggregates": "4.0.8",
+                "rxjs": "5.5.6",
                 "string-width": "2.1.1",
                 "strip-ansi": "4.0.0",
                 "through": "2.3.8"
@@ -2270,9 +2271,9 @@
             "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
         },
         "node-sp-auth": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/node-sp-auth/-/node-sp-auth-2.3.4.tgz",
-            "integrity": "sha512-fkB3THLLB3t/0iiSp1pw2p+9B8feY22LC/y01BWeX4boW1Vo3pEtKT6MSF889vShqgPLl1rZrEI/jYE8WFAvkg==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/node-sp-auth/-/node-sp-auth-2.4.0.tgz",
+            "integrity": "sha512-KjENVK5NZrPQEfimfwLUTc5wRUKpmE2w8aVZr9Lr5swJV68U+nR+pjmw50XUEWfCrtzuVsWk/6RFx3Ov3AgFFA==",
             "requires": {
                 "@types/bluebird": "3.5.20",
                 "@types/cookie": "0.1.29",
@@ -2288,36 +2289,23 @@
                 "httpntlm": "1.7.5",
                 "jsonwebtoken": "7.4.3",
                 "lodash": "4.17.5",
-                "node-sp-auth-config": "2.4.4",
+                "node-sp-auth-config": "2.4.5",
                 "request": "2.83.0",
                 "request-promise": "4.2.2",
                 "xmldoc": "0.5.1"
-            },
-            "dependencies": {
-                "@types/request": {
-                    "version": "2.47.0",
-                    "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.0.tgz",
-                    "integrity": "sha512-/KXM5oev+nNCLIgBjkwbk8VqxmzI56woD4VUxn95O+YeQ8hJzcSmIZ1IN3WexiqBb6srzDo2bdMbsXxgXNkz5Q==",
-                    "requires": {
-                        "@types/caseless": "0.12.1",
-                        "@types/form-data": "2.2.1",
-                        "@types/node": "6.0.101",
-                        "@types/tough-cookie": "2.3.2"
-                    }
-                }
             }
         },
         "node-sp-auth-config": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/node-sp-auth-config/-/node-sp-auth-config-2.4.4.tgz",
-            "integrity": "sha512-TTuIVcTC/Hj0lLXh/tIjwqJQrpb6q7Ufyn22faBDuuSJY/hA+7Mqe6+S2AHUAHC/ylcDybWuOpkRugCNbS0hVA==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/node-sp-auth-config/-/node-sp-auth-config-2.4.5.tgz",
+            "integrity": "sha512-5Cx1cN1zzs1aRzbMtmkQqehNKCkSmeoa4l8cxVesiE0IX4YW9BSfyKzHOABAcnHWfFdUs7kZxMBBVT4Fuxj84w==",
             "requires": {
                 "colors": "1.1.2",
                 "commander": "2.14.1",
                 "cpass": "2.0.3",
-                "inquirer": "4.0.2",
+                "inquirer": "5.1.0",
                 "mkdirp": "0.5.1",
-                "node-sp-auth": "2.3.4"
+                "node-sp-auth": "2.4.0"
             }
         },
         "node.extend": {
@@ -2720,17 +2708,12 @@
                 "is-promise": "2.1.0"
             }
         },
-        "rx-lite": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
-        },
-        "rx-lite-aggregates": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-            "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+        "rxjs": {
+            "version": "5.5.6",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+            "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
             "requires": {
-                "rx-lite": "4.0.8"
+                "symbol-observable": "1.0.1"
             }
         },
         "safe-buffer": {
@@ -2817,9 +2800,20 @@
                 "bluebird": "3.5.1",
                 "httpntlm": "1.7.5",
                 "lodash": "4.17.5",
-                "node-sp-auth": "2.3.4",
+                "node-sp-auth": "2.4.0",
                 "request": "2.83.0",
                 "request-promise": "4.2.2"
+            },
+            "dependencies": {
+                "@types/request": {
+                    "version": "0.0.31",
+                    "resolved": "https://registry.npmjs.org/@types/request/-/request-0.0.31.tgz",
+                    "integrity": "sha1-6ed2YfdsWWpv0O26YiAFZnFxuus=",
+                    "requires": {
+                        "@types/form-data": "2.2.1",
+                        "@types/node": "6.0.101"
+                    }
+                }
             }
         },
         "sparkles": {
@@ -2838,21 +2832,21 @@
             }
         },
         "sppull": {
-            "version": "2.2.5",
-            "resolved": "https://registry.npmjs.org/sppull/-/sppull-2.2.5.tgz",
-            "integrity": "sha512-ClIUJLcjbonikYLKvgS+bghxzzGimO4f5OMdIWsxTdM3ptlgPskK705mGkQYDCgSCqWhtLKt1qMJOre9TudMtw==",
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/sppull/-/sppull-2.2.6.tgz",
+            "integrity": "sha512-7ygXhaujhgmWpOPeLhRKfxIFZevwcQN6jXM/Q6nrsV1wblvlQsWfymxwKf4bjqmaxE67CdKBZdex8jvKoi8o+Q==",
             "requires": {
                 "colors": "1.1.2",
                 "mkdirp": "0.5.1",
-                "node-sp-auth-config": "2.4.4",
+                "node-sp-auth-config": "2.4.5",
                 "request": "2.83.0",
                 "sp-request": "2.1.3"
             }
         },
         "spsave": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/spsave/-/spsave-3.1.1.tgz",
-            "integrity": "sha512-B7EaF5ovQs3Or8d4ysS8WTGH8pukPN/M126WjAQOU9XrzczfN2o/Az1ogbMHIV+GEgsQW4Ofu+jAAEb7RjgyYw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/spsave/-/spsave-3.1.2.tgz",
+            "integrity": "sha512-fVe31e4iIKi0YaONt5XYSJrPZtG01kXv3SoOs5ZLuhrg7UPZfF/DMYElN+uelppQQL9xqR1Ee7snEWSEsPd/ZA==",
             "dev": true,
             "requires": {
                 "@types/bluebird": "3.5.5",
@@ -8970,6 +8964,11 @@
                 "has-flag": "3.0.0"
             }
         },
+        "symbol-observable": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+            "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+        },
         "tar": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
@@ -9079,8 +9078,7 @@
         "typescript": {
             "version": "2.7.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-            "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
-            "dev": true
+            "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
         },
         "underscore": {
             "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "Office 365",
         "o365"
     ],
-    "version": "1.2.0",
+    "version": "1.2.1",
     "publisher": "SiteGo",
     "icon": "assets/SiteGoLogo.png",
     "galleryBanner": {
@@ -31,7 +31,7 @@
         "url": "https://github.com/ReadySiteGo/SPGo.git"
     },
     "engines": {
-        "vscode": "^1.19.0"
+        "vscode": "^1.20.0"
     },
     "categories": [
         "Other"
@@ -151,7 +151,7 @@
         }
     },
     "scripts": {
-        "vscode:prepublish": "tsc -p ./ --skipLibCheck",
+        "vscode:prepublish": "tsc -p ./",
         "compile": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "node ./node_modules/vscode/bin/test"
@@ -160,17 +160,18 @@
         "@types/mocha": "^2.2.41",
         "@types/node": "^6.0.101",
         "mocha": "^2.3.3",
-        "spsave": "^3.1.1",
-        "typescript": "^2.7.2",
+        "spsave": "^3.1.2",
         "vscode": "^1.1.10"
     },
     "dependencies": {
         "fs-extra": "^4.0.3",
         "lodash": "^4.17.5",
+        "node-sp-auth": "^2.4.0",
         "parse-glob": "^3.0.4",
         "path": "^0.12.7",
         "sp-request": "^2.1.3",
-        "sppull": "^2.2.5",
+        "sppull": "^2.2.6",
+        "typescript": "^2.7.2",
         "vscode-uri": "^1.0.1"
     }
 }


### PR DESCRIPTION
## 1.2.1 - 2018-2-26
### Added
- SPGo now supports Germany, China, and the US Government's private Office 365 deployments! Not so private now, huh?!?
### Fixed
- Resolved a visual issue where a glob pattern matching 0 items would cause the progress spinner to spin endlessly.
- Resolved a number of dependency errors and version incompatibilities between SPGo, TypeScript, VSCode and various Typings.