### PR TITLE
1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 
+## 1.2.4 - 2018-5-10
+### Added
+- [This request from Github](https://github.com/readysitego/spgo/issues/35) will now allow you to specify a default check-in message using the `checkInMessage` config property in `SPGo.json`
+- [This other request from Github](https://github.com/readysitego/spgo/issues/34) will now allow you to manually reload config data from `SPGo.json` using the command `SPGO> Reload Configuration` or the shortcut `<alt> + r, <alt> + c`
+### Fixed
+- An issue where [Git integration caused unnecessary error messages in the SPGo output file](https://github.com/readysitego/spgo/issues/34)
+- You will now be prompted to enter a check-in message when you set "Publish a Major|Minor" Version" as your default save action.
+- Refactored our core promise chain to properly, and most-importantly: DRY-ly, handle errors. Errors should consistently log and the progress bar will once again cease its endless spinning.
+
 ## 1.2.3 - 2018-4-14
 ### Added
 - Glob support for retrieving files (e.g. /SiteAssets/*.*, /SiteAssets/*.css)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If configuration was successful, you should see a file similar to below:
 ```
 ### Additional Configuration Options ###
 #### Glob support for Publishing Workspace ####
-Entering a [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) pattern into a node called `publishWorkspaceGlobPattern` will cause SPGo to publish only files which match this glob pattern. For example, if you use another VSCode plugin to minify files on save, you can configure the `>SPGo: Publish local workspace` command to publish all minified files in the workspace with the format `<fiel>.min.<ext>` by setting the  `publishWorkspaceGlobPattern` property to `/**/*.min.*`.
+Entering a [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) pattern into a node called `publishWorkspaceGlobPattern` will cause SPGo to publish only files which match this glob pattern. For example, if you use another VSCode plugin to minify files on save, you can configure the `>SPGo: Publish local workspace` command to publish all minified files in the workspace with the format `<file>.min.<ext>` by setting the  `publishWorkspaceGlobPattern` property to `/**/*.min.*`.
 
 #### Populating Remote Files ####
 When you specify an array of remote folders in a node called `remoteFolders`, SPGo will recursively download the remote folder contents to your local workspace when you issue the Synchronize Files command `>SPGo: Populate Workspace`. 
@@ -65,6 +65,7 @@ Note: This WILL overwrite all local files.
 #### Example Config json ####
 ```json
 {
+    "checkInMessage" : "Your custom Check-in message here",
     "sourceDirectory": "src",
     "sharePointSiteUrl": "https://tenant.sharepoint.com/sites/MyProject",
     "publishingScope": "SaveOnly",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "o365",
         "ide"
     ],
-    "version": "1.2.2",
+    "version": "1.2.4",
     "publisher": "SiteGo",
     "icon": "assets/SiteGoLogo.png",
     "galleryBanner": {
@@ -85,6 +85,11 @@
                 "description": "Publish the current file to the server."
             },
             {
+                "command": "spgo.reloadConfiguration",
+                "title": "SPGo: Reload Configuration",
+                "description": "Reload the configuration file (SPGo.json) from disk."
+            },
+            {
                 "command": "spgo.resetCredentials",
                 "title": "SPGo: Reset credentials",
                 "description": "Reset the current user's SharePoint credentials."
@@ -113,6 +118,11 @@
                 "command": "spgo.publishMinor",
                 "when": "editorFocus",
                 "win": "alt+p"
+            },
+            {
+                "key": "alt+r alt+c",
+                "command": "spgo.reloadConfiguration",
+                "win": "alt+r alt+c"
             }
         ],
         "languages": [

--- a/src/appManager.ts
+++ b/src/appManager.ts
@@ -20,7 +20,7 @@ export class AppManager implements IAppManager {
         this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 5);
 
         //initialize Configuration file
-        initializeConfiguration(this).then(()=> {//config => {
+        initializeConfiguration(this).then(()=> {
             this.statusBarItem.text = 'SPGo enabled';
         }).catch(err => {
             Logger.showError('SPGo: Missing Configuration');

--- a/src/command/checkOutFile.ts
+++ b/src/command/checkOutFile.ts
@@ -10,6 +10,7 @@ import {UiHelper} from './../util/uiHelper';
 import {FileHelper} from './../util/fileHelper';
 import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationservice';
+import { ErrorHelper } from '../util/errorHelper';
 
 export default function checkOutFile(fileUri: vscode.Uri) : Thenable<any> {
 
@@ -24,7 +25,7 @@ export default function checkOutFile(fileUri: vscode.Uri) : Thenable<any> {
             AuthenticationService.verifyCredentials(vscode.window.spgo, fileUri)
                 .then((filePath) => fileService.checkoutFile(filePath))
                 .then(() => downloadFileAndCompare(fileUri, downloadPath))
-                .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
+                .catch(err => ErrorHelper.handleError(err))
         );
 
         
@@ -50,9 +51,7 @@ export default function checkOutFile(fileUri: vscode.Uri) : Thenable<any> {
                                     }
                                 });
                         },
-                        (err) => {
-                                Logger.outputError(err, vscode.window.spgo.outputChannel);
-                        });
+                        (err) => {ErrorHelper.handleError(err);});
                 })
         }
     }

--- a/src/command/compareFileWithServer.ts
+++ b/src/command/compareFileWithServer.ts
@@ -7,6 +7,7 @@ import {Logger} from '../util/logger';
 import {Constants} from './../constants';
 import {UiHelper} from './../util/uiHelper';
 import {FileHelper} from './../util/fileHelper';
+import { ErrorHelper } from '../util/errorHelper';
 import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationservice';
 
@@ -23,7 +24,7 @@ export default function compareFileWithServer(localPath : vscode.Uri) : Thenable
             AuthenticationService.verifyCredentials(vscode.window.spgo, localPath)
                 .then((localPath) => fileService.downloadFileMajorVersion(localPath, downloadPath))
                 .then((dlFileUrl) => openFileCompare(localPath, dlFileUrl))
-                .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
+                .catch(err => ErrorHelper.handleError(err))
         );
 
         function openFileCompare(localPath : vscode.Uri, dlFileUrl : any){            

--- a/src/command/configureWorkspace.ts
+++ b/src/command/configureWorkspace.ts
@@ -2,7 +2,7 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as vscode from 'vscode';
-import {Logger} from '../util/logger';
+import { ErrorHelper } from '../util/errorHelper';
 
 import {Constants} from './../constants';
 import initializeConfiguration from './../dao/configurationDao';
@@ -14,7 +14,7 @@ export default function configureWorkspace() {
         .then((cfg) => getPublishingScope(cfg))
         .then((cfg) => getAuthenticationType(cfg))
         .then((cfg) => finished(cfg))
-        .catch((err) => Logger.outputError(err, vscode.window.spgo.outputChannel));
+        .catch(err => ErrorHelper.handleError(err));
         
     
     function getSharePointSiteUrl() {

--- a/src/command/discardCheckOut.ts
+++ b/src/command/discardCheckOut.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import {Logger} from '../util/logger';
 import {UiHelper} from './../util/uiHelper';
 import {FileHelper} from './../util/fileHelper';
+import { ErrorHelper } from '../util/errorHelper';
 import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationservice';
 
@@ -21,7 +22,7 @@ export default function discardCheckOut(fileUri: vscode.Uri) : Thenable<any> {
                 .then(() => {
                     Logger.outputMessage(`Discard check-out successful for file ${fileUri.path}.`, vscode.window.spgo.outputChannel);
                 })
-                .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
+                .catch(err => ErrorHelper.handleError(err))
         );
     }
 }

--- a/src/command/getCurrentFileInformation.ts
+++ b/src/command/getCurrentFileInformation.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import {Logger} from '../util/logger';
 import {ISPFileInformation} from './../spgo';
 import {UiHelper} from './../util/uiHelper';
+import { ErrorHelper } from '../util/errorHelper';
 import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationservice';
 
@@ -17,7 +18,7 @@ export default function saveFile(textDocument: vscode.TextDocument) : Thenable<a
             AuthenticationService.verifyCredentials(vscode.window.spgo, textDocument)
                 .then((textDocument) => fileService.getFileInformation(textDocument))
                 .then((fileInfo) => showFileInformation(fileInfo))
-                .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
+                .catch(err => ErrorHelper.handleError(err))
         );
     }
 

--- a/src/command/populateWorkspace.ts
+++ b/src/command/populateWorkspace.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import {IError} from './../spgo';
 import {Logger} from '../util/logger';
 import {UiHelper} from './../util/uiHelper';
+import { ErrorHelper } from '../util/errorHelper';
 import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationservice';
 
@@ -15,7 +16,7 @@ export default function populateWorkspace() : Thenable<any> {
     return UiHelper.showStatusBarProgress('Populating workspace',
         AuthenticationService.verifyCredentials(vscode.window.spgo)
             .then(downloadFiles)
-            .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
+            .catch(err => ErrorHelper.handleError(err))
     );
 
     function downloadFiles() : Thenable<any> {

--- a/src/command/publishFile.ts
+++ b/src/command/publishFile.ts
@@ -6,6 +6,7 @@ import {Constants} from './../constants';
 import {IPublishingAction} from './../spgo';
 import {UiHelper} from './../util/uiHelper';
 import {FileHelper} from './../util/fileHelper';
+import {ErrorHelper} from './../util/errorHelper';
 import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationservice';
 
@@ -18,7 +19,7 @@ export default function publishFile(fileUri: vscode.Uri, publishingScope : strin
         let publishingInfo : IPublishingAction = {
             fileUri : fileUri,
             scope : publishingScope,
-            message : Constants.PUBLISHING_DEFAULT_MESSAGE
+            message : vscode.window.spgo.config.checkInMessage || Constants.PUBLISHING_DEFAULT_MESSAGE
         }
 
         Logger.outputMessage(`Publishing ${publishingScope} file version:  ${fileUri.path}`, vscode.window.spgo.outputChannel);
@@ -30,7 +31,7 @@ export default function publishFile(fileUri: vscode.Uri, publishingScope : strin
                 .then(function(){
                     Logger.outputMessage('File publish complete.', vscode.window.spgo.outputChannel);
                 })
-                .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
+                .catch(err => ErrorHelper.handleError(err))
         );
     }
 }

--- a/src/command/publishWorkspace.ts
+++ b/src/command/publishWorkspace.ts
@@ -5,6 +5,7 @@ import {Logger} from '../util/logger';
 import {Constants} from './../constants';
 import {IPublishingAction} from './../spgo';
 import {UiHelper} from './../util/uiHelper';
+import { ErrorHelper } from '../util/errorHelper';
 import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationservice';
 
@@ -12,7 +13,7 @@ export default function publishWorkspace() : Thenable<any> {
     let publishingInfo : IPublishingAction = {
         fileUri : null,
         scope : Constants.PUBLISHING_MAJOR,
-        message : Constants.PUBLISHING_DEFAULT_MESSAGE
+        message : vscode.window.spgo.config.checkInMessage || Constants.PUBLISHING_DEFAULT_MESSAGE
     }
     Logger.outputMessage('Starting Workspace Publish...', vscode.window.spgo.outputChannel);
     let fileService : SPFileService = new SPFileService();
@@ -21,6 +22,6 @@ export default function publishWorkspace() : Thenable<any> {
         AuthenticationService.verifyCredentials(vscode.window.spgo, publishingInfo)
             .then((publishingInfo) => UiHelper.getPublishingMessage(publishingInfo))
             .then((publishingInfo) => fileService.uploadWorkspaceToServer(publishingInfo))
-            .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
+            .catch(err => ErrorHelper.handleError(err))
     );
 }

--- a/src/command/resetCredentials.ts
+++ b/src/command/resetCredentials.ts
@@ -1,7 +1,7 @@
 'use strict';
 import * as vscode from 'vscode';
 
-import {Logger} from '../util/logger';
+import { ErrorHelper } from '../util/errorHelper';
 import {AuthenticationService} from './../service/authenticationservice';
 
 //Reset the Current user's Credentials.
@@ -9,5 +9,5 @@ export default function resetCredentials() : Promise<any> {
     vscode.window.spgo.credential = null;
 
     return AuthenticationService.verifyCredentials(vscode.window.spgo)
-        .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel));
+    .catch(err => ErrorHelper.handleError(err));
 }

--- a/src/command/retrieveFolder.ts
+++ b/src/command/retrieveFolder.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 
 import {Logger} from '../util/logger';
 import {UiHelper} from './../util/uiHelper';
+import { ErrorHelper } from '../util/errorHelper';
 import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationservice';
 
@@ -13,7 +14,7 @@ export default function retrieveFolder() : Thenable<any> {
     return UiHelper.showStatusBarProgress('Downloading files',
         AuthenticationService.verifyCredentials(vscode.window.spgo)
             .then(downloadFiles)
-            .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
+            .catch(err => ErrorHelper.handleError(err))
     );
 
     function downloadFiles() : Thenable<any> {
@@ -29,8 +30,7 @@ export default function retrieveFolder() : Thenable<any> {
                     .then(function() {
                         resolve();
                     }).catch(err => {
-                        Logger.outputError(err);
-                        reject();
+                        reject(err);
                     });
             });
         });

--- a/src/command/saveFile.ts
+++ b/src/command/saveFile.ts
@@ -6,6 +6,7 @@ import {Constants} from './../constants';
 import {IPublishingAction} from './../spgo';
 import {UiHelper} from './../util/uiHelper';
 import {FileHelper} from './../util/fileHelper';
+import { ErrorHelper } from '../util/errorHelper';
 import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationservice';
 
@@ -17,15 +18,15 @@ export default function saveFile(fileUri: vscode.Uri) : Thenable<any> {
         let publishAction : IPublishingAction = {
             fileUri : fileUri,
             scope : null,
-            message : Constants.PUBLISHING_DEFAULT_MESSAGE
+            message : vscode.window.spgo.config.checkInMessage || Constants.PUBLISHING_DEFAULT_MESSAGE
         }
         
         Logger.outputMessage(`Saving file:  ${fileUri.path}`, vscode.window.spgo.outputChannel);
 
         return UiHelper.showStatusBarProgress(`Saving file:  ${fileName}`,
             AuthenticationService.verifyCredentials(vscode.window.spgo, publishAction)
-                .then((publishAction) => fileService.uploadFileToServer(publishAction))  
-                .catch(err => Logger.outputError(err, vscode.window.spgo.outputChannel))
+                .then((publishAction) => fileService.uploadFileToServer(publishAction)) 
+                .catch(err => ErrorHelper.handleError(err))
         );
     }
 }

--- a/src/gateway/spFileGateway.ts
+++ b/src/gateway/spFileGateway.ts
@@ -7,7 +7,6 @@ import {ISPRequest} from 'sp-request';
 
 import {ISPFileInformation} from './../spgo'
 import {Logger} from '../util/logger';
-import {ErrorHelper} from './../util/errorHelper';
 import {RequestHelper} from './../util/requestHelper';
 
 export class SPFileGateway{
@@ -29,7 +28,8 @@ export class SPFileGateway{
                 .then( (response) => {
                     resolve(response);
                 })
-                .catch((err) => ErrorHelper.handleError(err, reject));
+                .catch((err) => reject(err));
+                // .catch((err) => ErrorHelper.handleError(err, reject));
         });
     }
 
@@ -43,7 +43,8 @@ export class SPFileGateway{
                     }
                     resolve(downloadResults);
                 })
-                .catch((err) => ErrorHelper.handleError(err, reject));
+                .catch((err) => reject(err));
+                // .catch((err) => ErrorHelper.handleError(err, reject));
         });
     }
 
@@ -55,7 +56,8 @@ export class SPFileGateway{
                     Logger.outputMessage(`Successfully downloaded ${downloadResults.length} files to: ${vscode.window.spgo.config.sourceDirectory + remoteFolder}`, vscode.window.spgo.outputChannel);
                     resolve(downloadResults);
                 })
-                .catch((err) => ErrorHelper.handleError(err, reject));
+                .catch((err) => reject(err));
+                // .catch((err) => ErrorHelper.handleError(err, reject));
         });
     }
 
@@ -89,7 +91,8 @@ export class SPFileGateway{
                             resolve(fileInfo);
                         }
                     })
-                    .catch((err) => ErrorHelper.handleErrorSilently(err, reject));
+                    .catch((err) => reject(err));
+                    // .catch((err) => ErrorHelper.handleErrorSilently(err, reject));
                 })
         });
     }
@@ -106,7 +109,8 @@ export class SPFileGateway{
                 .then(function(){
                     resolve();
                 })
-                .catch((err) => ErrorHelper.handleError(err, reject));
+                .catch((err) => reject(err));
+                // .catch((err) => ErrorHelper.handleError(err, reject));
         });
     }
 }

--- a/src/service/authenticationService.ts
+++ b/src/service/authenticationService.ts
@@ -76,9 +76,7 @@ export class AuthenticationService{
 						resolve(appManager);
 					}, err => {
 						appManager.credential = null;
-						Logger.showError('Invalid user credentials.', err)
-						reject(null);
-						throw err;
+						reject(err);
 					});
 			});
 		}

--- a/src/service/spFileService.ts
+++ b/src/service/spFileService.ts
@@ -13,7 +13,6 @@ import {Constants} from './../constants';
 import {IPublishingAction} from '../spgo';
 import {UrlHelper} from './../util/UrlHelper';
 import {FileHelper} from './../util/fileHelper';
-import {ErrorHelper} from './../util/errorHelper';
 import {RequestHelper} from './../util/requestHelper'
 import {SPFileGateway} from './../gateway/spFileGateway';
 import { DownloadFileOptionsFactory } from '../factory/downloadFileOptionsFactory';
@@ -32,8 +31,6 @@ export class SPFileService{
 
     public downloadFiles(remoteFolder : string) : Promise<any>{
         //format the remote folder to /<folder structure>/  
-        //remoteFolder = UrlHelper.formatWebFolder(remoteFolder);
-        //let sharePointSiteUrl : Uri = Uri.parse(vscode.window.spgo.config.sharePointSiteUrl);
         let factory : DownloadFileOptionsFactory = new DownloadFileOptionsFactory(remoteFolder);
     
         let context : any = {
@@ -126,7 +123,7 @@ export class SPFileService{
                     Logger.outputMessage(`file ${publishingInfo.fileUri.fsPath} successfully saved to server.`, vscode.window.spgo.outputChannel);
                     resolve(response);
                 })
-                .catch((err) => ErrorHelper.handleError(err, reject));
+                .catch((err) => reject(err));
         });
     }
 
@@ -151,14 +148,14 @@ export class SPFileService{
                     Logger.outputMessage('Workspace Publish complete.', vscode.window.spgo.outputChannel);
                     resolve(response);
                 })
-                .catch((err) => ErrorHelper.handleError(err, reject));
+                .catch((err) => reject(err));
         });
     }
 
     private buildCoreUploadOptions(publishingInfo : IPublishingAction) : any {
         var coreOptions = {
             siteUrl: vscode.window.spgo.config.sharePointSiteUrl,
-            checkinMessage : publishingInfo.message,
+            checkinMessage : encodeURI(publishingInfo.message),
             checkin : false
         };
     

--- a/src/spgo.ts
+++ b/src/spgo.ts
@@ -23,6 +23,7 @@ export interface ICredential{
 export interface IConfig{
     authenticationType? : string;
     authenticationDetails? : any;
+    checkInMessage? : string,
     publishingScope? : string;
     publishWorkspaceGlobPattern? : string;
     remoteFolders? : string[];

--- a/src/util/errorHelper.ts
+++ b/src/util/errorHelper.ts
@@ -6,7 +6,7 @@ import {Logger} from '../util/logger';
 
 export class ErrorHelper{
 
-    static handleError(err, reject, outputMethod?){
+    static handleError(err, outputMethod?){
         outputMethod = outputMethod || Logger.showError;
 
         //HACK: Come up with a better way to detect if this error was due to credentials
@@ -30,11 +30,9 @@ export class ErrorHelper{
                 Logger.outputError(err, vscode.window.spgo.outputChannel);
             }
         }
-        
-        reject(err);
     }
 
-    static handleErrorSilently(err, reject){
-        this.handleError(err, reject, Logger.outputError);
-    }
+    // static handleErrorSilently(err, reject){
+    //     this.handleError(err, reject, Logger.outputError);
+    // }
 }

--- a/src/util/uiHelper.ts
+++ b/src/util/uiHelper.ts
@@ -1,5 +1,6 @@
 'use strict';
 import * as vscode from 'vscode';
+
 import {IPublishingAction} from './../spgo';
 
 export class UiHelper{
@@ -26,10 +27,8 @@ export class UiHelper{
             title: message
         }
     
-        return vscode.window.withProgress(options, 
-            async () => {
-                return action;
-            }
-        );
+        return vscode.window.withProgress(options, async () => {
+            return action;
+        });
     }
 }


### PR DESCRIPTION
## 1.2.4 - 2018-5-10
### Added
- [This request from Github](https://github.com/readysitego/spgo/issues/35) will now allow you to specify a default check-in message using the `checkInMessage` config property in `SPGo.json`
- [This other request from Github](https://github.com/readysitego/spgo/issues/34) will now allow you to manually reload config data from `SPGo.json` using the command `SPGO> Reload Configuration` or the shortcut `<alt> + r, <alt> + c`
### Fixed
- An issue where [Git integration caused unnecessary error messages in the SPGo output file](https://github.com/readysitego/spgo/issues/34)
- You will now be prompted to enter a check-in message when you set "Publish a Major|Minor" Version" as your default save action.
- Refactored our core promise chain to properly, and most-importantly: DRY-ly, handle errors. Errors should consistently log and the progress bar will once again cease its endless spinning.
