### PR TITLE
1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 1.3.1 - 2018-6-
+## 1.3.1 - 2018-6-7
 ### Added
 - Integrated [cpass](https://www.npmjs.com/package/cpass), allowing users to store credentials for each SharePoint site, removing the need to always reenter creds when launching SPGo. [Issue 47](https://github.com/readysitego/spgo/issues/47)
+### Changed
+- The `SPGo> Publish a major version of the current file` and `SPGo> Publish a major version of the current file` commands now works at the folder level. All other context menu items will gracefully fail with a message that they do not yet support operations at the folder-level.
 ### Fixed
 - Found/fixed another Glob issue, related to globstar searches (e.g. `/directory/**/*.*`), hopefully resolving all cases of [Issue 46](https://github.com/readysitego/spgo/issues/46)
 - Better URL concatenation prevents double-slashes when setting a SharePoint site URL ending in a slash, which resolves [Issue 50](https://github.com/readysitego/spgo/issues/50)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.3.1 - 2018-6-
+### Added
+- Integrated [cpass](https://www.npmjs.com/package/cpass), allowing users to store credentials for each SharePoint site, removing the need to always reenter creds when launching SPGo. [Issue 47](https://github.com/readysitego/spgo/issues/47)
+### Fixed
+- Found/fixed another Glob issue, related to globstar searches (e.g. `/directory/**/*.*`), hopefully resolving all cases of [Issue 46](https://github.com/readysitego/spgo/issues/46)
+- Better URL concatenation prevents double-slashes when setting a SharePoint site URL ending in a slash, which resolves [Issue 50](https://github.com/readysitego/spgo/issues/50)
 
 ## 1.3.0 - 2018-6-1
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,15 @@
             "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
             "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
             "requires": {
-                "@types/node": "*"
+                "@types/node": "6.0.110"
+            }
+        },
+        "@types/fs-extra": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.2.tgz",
+            "integrity": "sha512-Q3FWsbdmkQd1ib11A4XNWQvRD//5KpPoGawA8aB2DR7pWKoW9XQv3+dGxD/Z1eVFze23Okdo27ZQytVFlweKvQ==",
+            "requires": {
+                "@types/node": "6.0.110"
             }
         },
         "@types/glob": {
@@ -42,9 +50,9 @@
             "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
             "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
             "requires": {
-                "@types/events": "*",
-                "@types/minimatch": "*",
-                "@types/node": "*"
+                "@types/events": "1.2.0",
+                "@types/minimatch": "3.0.3",
+                "@types/node": "6.0.110"
             }
         },
         "@types/glob-stream": {
@@ -52,8 +60,8 @@
             "resolved": "https://registry.npmjs.org/@types/glob-stream/-/glob-stream-6.1.0.tgz",
             "integrity": "sha512-RHv6ZQjcTncXo3thYZrsbAVwoy4vSKosSWhuhuQxLOTv74OJuFQxXkmUuZCr3q9uNBEVCvIzmZL/FeRNbHZGUg==",
             "requires": {
-                "@types/glob": "*",
-                "@types/node": "*"
+                "@types/glob": "5.0.35",
+                "@types/node": "6.0.110"
             }
         },
         "@types/jsonwebtoken": {
@@ -61,7 +69,7 @@
             "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.7.tgz",
             "integrity": "sha512-lq9X76APpxGJDUe1VptL1P5GrogqhPCH+SDy94+gaBJw7Hhj6hwrVC6zuxAx2GrgktkBuwydESZBvPfrdBoOEg==",
             "requires": {
-                "@types/node": "*"
+                "@types/node": "6.0.110"
             }
         },
         "@types/lodash": {
@@ -90,7 +98,7 @@
             "resolved": "https://registry.npmjs.org/@types/node-notifier/-/node-notifier-0.0.28.tgz",
             "integrity": "sha1-hro9OqjZGDUswxkdiN4yiyDck8E=",
             "requires": {
-                "@types/node": "*"
+                "@types/node": "6.0.110"
             }
         },
         "@types/request": {
@@ -98,10 +106,10 @@
             "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.0.tgz",
             "integrity": "sha512-/KXM5oev+nNCLIgBjkwbk8VqxmzI56woD4VUxn95O+YeQ8hJzcSmIZ1IN3WexiqBb6srzDo2bdMbsXxgXNkz5Q==",
             "requires": {
-                "@types/caseless": "*",
-                "@types/form-data": "*",
-                "@types/node": "*",
-                "@types/tough-cookie": "*"
+                "@types/caseless": "0.12.1",
+                "@types/form-data": "2.2.1",
+                "@types/node": "6.0.110",
+                "@types/tough-cookie": "2.3.3"
             }
         },
         "@types/request-promise": {
@@ -109,8 +117,8 @@
             "resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.41.tgz",
             "integrity": "sha512-qlx6COxSTdSFHY9oX9v2zL1I05hgz5lwqYiXa2SFL2nDxAiG5KK8rnllLBH7k6OqzS3Ck0bWbxlGVdrZhS6oNw==",
             "requires": {
-                "@types/bluebird": "*",
-                "@types/request": "*"
+                "@types/bluebird": "3.5.20",
+                "@types/request": "2.47.0"
             }
         },
         "@types/tough-cookie": {
@@ -123,7 +131,7 @@
             "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-1.2.30.tgz",
             "integrity": "sha1-kRXAxFxAxXVziQa+n7Tfb1ueUBM=",
             "requires": {
-                "@types/node": "*"
+                "@types/node": "6.0.110"
             }
         },
         "@types/vinyl-fs": {
@@ -131,9 +139,9 @@
             "resolved": "https://registry.npmjs.org/@types/vinyl-fs/-/vinyl-fs-0.0.28.tgz",
             "integrity": "sha1-RmMBe8gCxlcOrk80Cf1cq/l8v94=",
             "requires": {
-                "@types/glob-stream": "*",
-                "@types/node": "*",
-                "@types/vinyl": "*"
+                "@types/glob-stream": "6.1.0",
+                "@types/node": "6.0.110",
+                "@types/vinyl": "1.2.30"
             }
         },
         "ajv": {
@@ -141,10 +149,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
+                "co": "4.6.0",
+                "fast-deep-equal": "1.1.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
             }
         },
         "ansi-cyan": {
@@ -186,7 +194,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.1"
             }
         },
         "ansi-wrap": {
@@ -199,8 +207,8 @@
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "requires": {
-                "arr-flatten": "^1.0.1",
-                "array-slice": "^0.2.3"
+                "arr-flatten": "1.1.0",
+                "array-slice": "0.2.3"
             }
         },
         "arr-flatten": {
@@ -228,7 +236,7 @@
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "requires": {
-                "array-uniq": "^1.0.1"
+                "array-uniq": "1.0.3"
             }
         },
         "array-uniq": {
@@ -282,7 +290,7 @@
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
             "optional": true,
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "beeper": {
@@ -295,7 +303,7 @@
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.1"
             }
         },
         "bluebird": {
@@ -308,7 +316,7 @@
             "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
             "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
             "requires": {
-                "hoek": "4.x.x"
+                "hoek": "4.2.1"
             },
             "dependencies": {
                 "hoek": {
@@ -323,7 +331,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -332,9 +340,9 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "requires": {
-                "expand-range": "^1.8.1",
-                "preserve": "^0.2.0",
-                "repeat-element": "^1.1.2"
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
             }
         },
         "browser-stdout": {
@@ -367,9 +375,9 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.4.0"
             }
         },
         "chardet": {
@@ -382,7 +390,7 @@
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "requires": {
-                "restore-cursor": "^2.0.0"
+                "restore-cursor": "2.0.0"
             }
         },
         "cli-width": {
@@ -410,9 +418,9 @@
             "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "requires": {
-                "inherits": "^2.0.1",
-                "process-nextick-args": "^2.0.0",
-                "readable-stream": "^2.3.5"
+                "inherits": "2.0.1",
+                "process-nextick-args": "2.0.0",
+                "readable-stream": "2.3.6"
             }
         },
         "co": {
@@ -425,7 +433,7 @@
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "requires": {
-                "color-name": "^1.1.1"
+                "color-name": "1.1.3"
             }
         },
         "color-name": {
@@ -448,7 +456,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
@@ -481,8 +489,8 @@
             "resolved": "https://registry.npmjs.org/cpass/-/cpass-2.0.3.tgz",
             "integrity": "sha512-bFswRHZf/O6RSitgeatNQ9pyzdeoTOl3+lLWGMIDF4BnHWMnuAxkl0qyN3sWLOpmUjjP6cckC7as8LUWWf/i4Q==",
             "requires": {
-                "os": "^0.1.1",
-                "simple-encryptor": "^1.1.1"
+                "os": "0.1.1",
+                "simple-encryptor": "1.3.0"
             }
         },
         "cryptiles": {
@@ -490,7 +498,7 @@
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
             "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
             "requires": {
-                "boom": "5.x.x"
+                "boom": "5.2.0"
             },
             "dependencies": {
                 "boom": {
@@ -498,7 +506,7 @@
                     "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
                     "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                     "requires": {
-                        "hoek": "4.x.x"
+                        "hoek": "4.2.1"
                     }
                 },
                 "hoek": {
@@ -513,7 +521,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "dateformat": {
@@ -543,7 +551,7 @@
             "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "requires": {
-                "is-obj": "^1.0.0"
+                "is-obj": "1.0.1"
             }
         },
         "delayed-stream": {
@@ -567,7 +575,7 @@
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "requires": {
-                "readable-stream": "~1.1.9"
+                "readable-stream": "1.1.14"
             },
             "dependencies": {
                 "isarray": {
@@ -580,10 +588,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -598,10 +606,10 @@
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
-                "stream-shift": "^1.0.0"
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.1",
+                "readable-stream": "2.3.6",
+                "stream-shift": "1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -610,7 +618,7 @@
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
             "optional": true,
             "requires": {
-                "jsbn": "~0.1.0"
+                "jsbn": "0.1.1"
             }
         },
         "ecdsa-sig-formatter": {
@@ -618,7 +626,7 @@
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
             "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "end-of-stream": {
@@ -626,7 +634,7 @@
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
             }
         },
         "escape-string-regexp": {
@@ -639,13 +647,13 @@
             "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "requires": {
-                "duplexer": "~0.1.1",
-                "from": "~0",
-                "map-stream": "~0.1.0",
+                "duplexer": "0.1.1",
+                "from": "0.1.7",
+                "map-stream": "0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3",
-                "stream-combiner": "~0.0.4",
-                "through": "~2.3.1"
+                "split": "0.3.3",
+                "stream-combiner": "0.0.4",
+                "through": "2.3.8"
             }
         },
         "expand-brackets": {
@@ -653,7 +661,7 @@
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "requires": {
-                "is-posix-bracket": "^0.1.0"
+                "is-posix-bracket": "0.1.1"
             }
         },
         "expand-range": {
@@ -661,7 +669,7 @@
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "requires": {
-                "fill-range": "^2.1.0"
+                "fill-range": "2.2.4"
             }
         },
         "extend": {
@@ -674,7 +682,7 @@
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "requires": {
-                "kind-of": "^1.1.0"
+                "kind-of": "1.1.0"
             }
         },
         "external-editor": {
@@ -682,9 +690,9 @@
             "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "requires": {
-                "chardet": "^0.4.0",
-                "iconv-lite": "^0.4.17",
-                "tmp": "^0.0.33"
+                "chardet": "0.4.2",
+                "iconv-lite": "0.4.23",
+                "tmp": "0.0.33"
             }
         },
         "extglob": {
@@ -692,7 +700,7 @@
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
             }
         },
         "extsprintf": {
@@ -705,9 +713,9 @@
             "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "requires": {
-                "ansi-gray": "^0.1.1",
-                "color-support": "^1.1.3",
-                "time-stamp": "^1.0.0"
+                "ansi-gray": "0.1.1",
+                "color-support": "1.1.3",
+                "time-stamp": "1.1.0"
             }
         },
         "fast-deep-equal": {
@@ -725,7 +733,7 @@
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "requires": {
-                "pend": "~1.2.0"
+                "pend": "1.2.0"
             }
         },
         "figures": {
@@ -733,7 +741,7 @@
             "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
             "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "requires": {
-                "escape-string-regexp": "^1.0.5"
+                "escape-string-regexp": "1.0.5"
             }
         },
         "filename-regex": {
@@ -746,11 +754,11 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "requires": {
-                "is-number": "^2.1.0",
-                "isobject": "^2.0.0",
-                "randomatic": "^3.0.0",
-                "repeat-element": "^1.1.2",
-                "repeat-string": "^1.5.2"
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "3.0.0",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
             }
         },
         "first-chunk-stream": {
@@ -768,7 +776,7 @@
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "requires": {
-                "for-in": "^1.0.1"
+                "for-in": "1.0.2"
             }
         },
         "forever-agent": {
@@ -781,9 +789,9 @@
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "requires": {
-                "asynckit": "^0.4.0",
+                "asynckit": "0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
+                "mime-types": "2.1.18"
             }
         },
         "from": {
@@ -796,9 +804,9 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
             "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
+                "graceful-fs": "4.1.11",
+                "jsonfile": "4.0.0",
+                "universalify": "0.1.1"
             }
         },
         "fs.realpath": {
@@ -811,10 +819,10 @@
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "inherits": "~2.0.0",
-                "mkdirp": ">=0.5 0",
-                "rimraf": "2"
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.1",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
             }
         },
         "getpass": {
@@ -822,7 +830,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "glob": {
@@ -830,11 +838,11 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
             "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
             "requires": {
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "2 || 3",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "inflight": "1.0.6",
+                "inherits": "2.0.1",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "glob-base": {
@@ -842,8 +850,8 @@
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "requires": {
-                "glob-parent": "^2.0.0",
-                "is-glob": "^2.0.0"
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
             }
         },
         "glob-parent": {
@@ -851,7 +859,7 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "requires": {
-                "is-glob": "^2.0.0"
+                "is-glob": "2.0.1"
             }
         },
         "glob-stream": {
@@ -859,14 +867,14 @@
             "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "requires": {
-                "extend": "^3.0.0",
-                "glob": "^5.0.3",
-                "glob-parent": "^3.0.0",
-                "micromatch": "^2.3.7",
-                "ordered-read-streams": "^0.3.0",
-                "through2": "^0.6.0",
-                "to-absolute-glob": "^0.1.1",
-                "unique-stream": "^2.0.2"
+                "extend": "3.0.1",
+                "glob": "5.0.15",
+                "glob-parent": "3.1.0",
+                "micromatch": "2.3.11",
+                "ordered-read-streams": "0.3.0",
+                "through2": "0.6.5",
+                "to-absolute-glob": "0.1.1",
+                "unique-stream": "2.2.1"
             },
             "dependencies": {
                 "glob": {
@@ -874,11 +882,11 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "requires": {
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "2 || 3",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.1",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "glob-parent": {
@@ -886,8 +894,8 @@
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "requires": {
-                        "is-glob": "^3.1.0",
-                        "path-dirname": "^1.0.0"
+                        "is-glob": "3.1.0",
+                        "path-dirname": "1.0.2"
                     }
                 },
                 "is-extglob": {
@@ -900,7 +908,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "requires": {
-                        "is-extglob": "^2.1.0"
+                        "is-extglob": "2.1.1"
                     }
                 },
                 "isarray": {
@@ -913,10 +921,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -929,8 +937,8 @@
                     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
                     }
                 }
             }
@@ -940,12 +948,12 @@
             "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
             "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
             "requires": {
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "glob": "^6.0.1",
-                "object-assign": "^4.0.1",
-                "pify": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "glob": "6.0.4",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
             }
         },
         "glogg": {
@@ -953,7 +961,7 @@
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "requires": {
-                "sparkles": "^1.0.0"
+                "sparkles": "1.0.1"
             }
         },
         "graceful-fs": {
@@ -977,9 +985,9 @@
             "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "requires": {
-                "deep-assign": "^1.0.0",
-                "stat-mode": "^0.2.0",
-                "through2": "^2.0.0"
+                "deep-assign": "1.0.0",
+                "stat-mode": "0.2.2",
+                "through2": "2.0.3"
             }
         },
         "gulp-filter": {
@@ -987,9 +995,9 @@
             "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "requires": {
-                "multimatch": "^2.0.0",
-                "plugin-error": "^0.1.2",
-                "streamfilter": "^1.0.5"
+                "multimatch": "2.1.0",
+                "plugin-error": "0.1.2",
+                "streamfilter": "1.0.7"
             }
         },
         "gulp-gunzip": {
@@ -997,8 +1005,8 @@
             "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "requires": {
-                "through2": "~0.6.5",
-                "vinyl": "~0.4.6"
+                "through2": "0.6.5",
+                "vinyl": "0.4.6"
             },
             "dependencies": {
                 "clone": {
@@ -1016,10 +1024,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
+                        "string_decoder": "0.10.31"
                     }
                 },
                 "string_decoder": {
@@ -1032,8 +1040,8 @@
                     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "requires": {
-                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-                        "xtend": ">=4.0.0 <4.1.0-0"
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
                     }
                 },
                 "vinyl": {
@@ -1041,8 +1049,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "0.2.0",
+                        "clone-stats": "0.0.1"
                     }
                 }
             }
@@ -1052,11 +1060,11 @@
             "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.0.tgz",
             "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
             "requires": {
-                "event-stream": "^3.3.4",
-                "node.extend": "^1.1.2",
-                "request": "^2.79.0",
-                "through2": "^2.0.3",
-                "vinyl": "^2.0.1"
+                "event-stream": "3.3.4",
+                "node.extend": "1.1.6",
+                "request": "2.86.0",
+                "through2": "2.0.3",
+                "vinyl": "2.1.0"
             },
             "dependencies": {
                 "clone": {
@@ -1079,12 +1087,12 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.1",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -1094,11 +1102,11 @@
             "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "requires": {
-                "convert-source-map": "^1.1.1",
-                "graceful-fs": "^4.1.2",
-                "strip-bom": "^2.0.0",
-                "through2": "^2.0.0",
-                "vinyl": "^1.0.0"
+                "convert-source-map": "1.5.1",
+                "graceful-fs": "4.1.11",
+                "strip-bom": "2.0.0",
+                "through2": "2.0.3",
+                "vinyl": "1.2.0"
             }
         },
         "gulp-symdest": {
@@ -1106,10 +1114,10 @@
             "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "requires": {
-                "event-stream": "^3.3.1",
-                "mkdirp": "^0.5.1",
-                "queue": "^3.1.0",
-                "vinyl-fs": "^2.4.3"
+                "event-stream": "3.3.4",
+                "mkdirp": "0.5.1",
+                "queue": "3.1.0",
+                "vinyl-fs": "2.4.4"
             }
         },
         "gulp-untar": {
@@ -1117,11 +1125,11 @@
             "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
             "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
             "requires": {
-                "event-stream": "~3.3.4",
-                "gulp-util": "~3.0.8",
-                "streamifier": "~0.1.1",
-                "tar": "^2.2.1",
-                "through2": "~2.0.3"
+                "event-stream": "3.3.4",
+                "gulp-util": "3.0.8",
+                "streamifier": "0.1.1",
+                "tar": "2.2.1",
+                "through2": "2.0.3"
             }
         },
         "gulp-util": {
@@ -1129,24 +1137,24 @@
             "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "requires": {
-                "array-differ": "^1.0.0",
-                "array-uniq": "^1.0.2",
-                "beeper": "^1.0.0",
-                "chalk": "^1.0.0",
-                "dateformat": "^2.0.0",
-                "fancy-log": "^1.1.0",
-                "gulplog": "^1.0.0",
-                "has-gulplog": "^0.1.0",
-                "lodash._reescape": "^3.0.0",
-                "lodash._reevaluate": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.template": "^3.0.0",
-                "minimist": "^1.1.0",
-                "multipipe": "^0.1.2",
-                "object-assign": "^3.0.0",
+                "array-differ": "1.0.0",
+                "array-uniq": "1.0.3",
+                "beeper": "1.1.1",
+                "chalk": "1.1.3",
+                "dateformat": "2.2.0",
+                "fancy-log": "1.3.2",
+                "gulplog": "1.0.0",
+                "has-gulplog": "0.1.0",
+                "lodash._reescape": "3.0.0",
+                "lodash._reevaluate": "3.0.0",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.template": "3.6.2",
+                "minimist": "1.2.0",
+                "multipipe": "0.1.2",
+                "object-assign": "3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "^2.0.0",
-                "vinyl": "^0.5.0"
+                "through2": "2.0.3",
+                "vinyl": "0.5.3"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -1164,11 +1172,11 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
                     }
                 },
                 "minimist": {
@@ -1186,7 +1194,7 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "supports-color": {
@@ -1199,8 +1207,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
                     "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
                     "requires": {
-                        "clone": "^1.0.0",
-                        "clone-stats": "^0.0.1",
+                        "clone": "1.0.4",
+                        "clone-stats": "0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -1211,13 +1219,13 @@
             "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "requires": {
-                "event-stream": "^3.3.1",
-                "queue": "^4.2.1",
-                "through2": "^2.0.3",
-                "vinyl": "^2.0.2",
-                "vinyl-fs": "^2.0.0",
-                "yauzl": "^2.2.1",
-                "yazl": "^2.2.1"
+                "event-stream": "3.3.4",
+                "queue": "4.4.2",
+                "through2": "2.0.3",
+                "vinyl": "2.1.0",
+                "vinyl-fs": "2.4.4",
+                "yauzl": "2.9.1",
+                "yazl": "2.4.3"
             },
             "dependencies": {
                 "clone": {
@@ -1235,7 +1243,7 @@
                     "resolved": "https://registry.npmjs.org/queue/-/queue-4.4.2.tgz",
                     "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
                     "requires": {
-                        "inherits": "~2.0.0"
+                        "inherits": "2.0.1"
                     }
                 },
                 "replace-ext": {
@@ -1248,12 +1256,12 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "requires": {
-                        "clone": "^2.1.1",
-                        "clone-buffer": "^1.0.0",
-                        "clone-stats": "^1.0.0",
-                        "cloneable-readable": "^1.0.0",
-                        "remove-trailing-separator": "^1.0.1",
-                        "replace-ext": "^1.0.0"
+                        "clone": "2.1.1",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.1.2",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
                     }
                 }
             }
@@ -1263,7 +1271,7 @@
             "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "requires": {
-                "glogg": "^1.0.0"
+                "glogg": "1.0.1"
             }
         },
         "har-schema": {
@@ -1276,8 +1284,8 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
             }
         },
         "has-ansi": {
@@ -1285,7 +1293,7 @@
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -1305,7 +1313,7 @@
             "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "requires": {
-                "sparkles": "^1.0.0"
+                "sparkles": "1.0.1"
             }
         },
         "hawk": {
@@ -1313,10 +1321,10 @@
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
             "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
             "requires": {
-                "boom": "4.x.x",
-                "cryptiles": "3.x.x",
-                "hoek": "4.x.x",
-                "sntp": "2.x.x"
+                "boom": "4.3.1",
+                "cryptiles": "3.1.2",
+                "hoek": "4.2.1",
+                "sntp": "2.1.0"
             },
             "dependencies": {
                 "hoek": {
@@ -1341,9 +1349,9 @@
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.1"
             }
         },
         "httpntlm": {
@@ -1351,8 +1359,8 @@
             "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.7.5.tgz",
             "integrity": "sha1-zRVY7ZMSVBjs5b+CTBM1Z1/u3sw=",
             "requires": {
-                "httpreq": ">=0.4.22",
-                "underscore": "~1.7.0"
+                "httpreq": "0.4.24",
+                "underscore": "1.7.0"
             }
         },
         "httpreq": {
@@ -1365,7 +1373,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
             "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
             "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": "2.1.2"
             }
         },
         "inflight": {
@@ -1373,8 +1381,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -1387,19 +1395,19 @@
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
             "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
             "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.0",
-                "cli-cursor": "^2.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^2.1.0",
-                "figures": "^2.0.0",
-                "lodash": "^4.3.0",
+                "ansi-escapes": "3.1.0",
+                "chalk": "2.4.1",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.2.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.10",
                 "mute-stream": "0.0.7",
-                "run-async": "^2.2.0",
-                "rxjs": "^5.5.2",
-                "string-width": "^2.1.0",
-                "strip-ansi": "^4.0.0",
-                "through": "^2.3.6"
+                "run-async": "2.3.0",
+                "rxjs": "5.5.10",
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "through": "2.3.8"
             }
         },
         "is": {
@@ -1422,7 +1430,7 @@
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "requires": {
-                "is-primitive": "^2.0.0"
+                "is-primitive": "2.0.0"
             }
         },
         "is-extendable": {
@@ -1445,7 +1453,7 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "requires": {
-                "is-extglob": "^1.0.0"
+                "is-extglob": "1.0.0"
             }
         },
         "is-number": {
@@ -1453,7 +1461,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -1461,7 +1469,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -1563,10 +1571,10 @@
             "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
             "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
             "requires": {
-                "hoek": "2.x.x",
-                "isemail": "1.x.x",
-                "moment": "2.x.x",
-                "topo": "1.x.x"
+                "hoek": "2.16.3",
+                "isemail": "1.2.0",
+                "moment": "2.22.1",
+                "topo": "1.1.0"
             }
         },
         "jsbn": {
@@ -1590,7 +1598,7 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "requires": {
-                "jsonify": "~0.0.0"
+                "jsonify": "0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -1603,7 +1611,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "^4.1.6"
+                "graceful-fs": "4.1.11"
             }
         },
         "jsonify": {
@@ -1616,11 +1624,11 @@
             "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
             "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
             "requires": {
-                "joi": "^6.10.1",
-                "jws": "^3.1.4",
-                "lodash.once": "^4.0.0",
-                "ms": "^2.0.0",
-                "xtend": "^4.0.1"
+                "joi": "6.10.1",
+                "jws": "3.1.5",
+                "lodash.once": "4.1.1",
+                "ms": "2.1.1",
+                "xtend": "4.0.1"
             }
         },
         "jsprim": {
@@ -1641,7 +1649,7 @@
             "requires": {
                 "buffer-equal-constant-time": "1.0.1",
                 "ecdsa-sig-formatter": "1.0.10",
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "jws": {
@@ -1649,8 +1657,8 @@
             "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
             "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
             "requires": {
-                "jwa": "^1.1.5",
-                "safe-buffer": "^5.0.1"
+                "jwa": "1.1.6",
+                "safe-buffer": "5.1.2"
             }
         },
         "kind-of": {
@@ -1663,7 +1671,7 @@
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "requires": {
-                "readable-stream": "^2.0.5"
+                "readable-stream": "2.3.6"
             }
         },
         "lodash": {
@@ -1721,7 +1729,7 @@
             "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "requires": {
-                "lodash._root": "^3.0.0"
+                "lodash._root": "3.0.1"
             }
         },
         "lodash.isarguments": {
@@ -1744,9 +1752,9 @@
             "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "requires": {
-                "lodash._getnative": "^3.0.0",
-                "lodash.isarguments": "^3.0.0",
-                "lodash.isarray": "^3.0.0"
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
             }
         },
         "lodash.once": {
@@ -1764,15 +1772,15 @@
             "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "requires": {
-                "lodash._basecopy": "^3.0.0",
-                "lodash._basetostring": "^3.0.0",
-                "lodash._basevalues": "^3.0.0",
-                "lodash._isiterateecall": "^3.0.0",
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0",
-                "lodash.keys": "^3.0.0",
-                "lodash.restparam": "^3.0.0",
-                "lodash.templatesettings": "^3.0.0"
+                "lodash._basecopy": "3.0.1",
+                "lodash._basetostring": "3.0.1",
+                "lodash._basevalues": "3.0.0",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0",
+                "lodash.keys": "3.1.2",
+                "lodash.restparam": "3.6.1",
+                "lodash.templatesettings": "3.1.1"
             }
         },
         "lodash.templatesettings": {
@@ -1780,8 +1788,8 @@
             "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "requires": {
-                "lodash._reinterpolate": "^3.0.0",
-                "lodash.escape": "^3.0.0"
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0"
             }
         },
         "lru-cache": {
@@ -1805,7 +1813,7 @@
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "requires": {
-                "readable-stream": "^2.0.1"
+                "readable-stream": "2.3.6"
             }
         },
         "micromatch": {
@@ -1813,19 +1821,19 @@
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "requires": {
-                "arr-diff": "^2.0.0",
-                "array-unique": "^0.2.1",
-                "braces": "^1.8.2",
-                "expand-brackets": "^0.1.4",
-                "extglob": "^0.3.1",
-                "filename-regex": "^2.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "normalize-path": "^2.0.1",
-                "object.omit": "^2.0.0",
-                "parse-glob": "^3.0.4",
-                "regex-cache": "^0.4.2"
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
             },
             "dependencies": {
                 "arr-diff": {
@@ -1833,7 +1841,7 @@
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "requires": {
-                        "arr-flatten": "^1.0.1"
+                        "arr-flatten": "1.1.0"
                     }
                 },
                 "kind-of": {
@@ -1841,7 +1849,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -1856,7 +1864,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "requires": {
-                "mime-db": "~1.33.0"
+                "mime-db": "1.33.0"
             }
         },
         "mimic-fn": {
@@ -1869,7 +1877,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -1921,8 +1929,8 @@
                     "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
                     "dev": true,
                     "requires": {
-                        "inherits": "2",
-                        "minimatch": "0.3"
+                        "inherits": "2.0.1",
+                        "minimatch": "0.3.0"
                     }
                 },
                 "minimatch": {
@@ -1931,8 +1939,8 @@
                     "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "2",
-                        "sigmund": "~1.0.0"
+                        "lru-cache": "2.7.3",
+                        "sigmund": "1.0.1"
                     }
                 },
                 "supports-color": {
@@ -1958,10 +1966,10 @@
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "requires": {
-                "array-differ": "^1.0.0",
-                "array-union": "^1.0.1",
-                "arrify": "^1.0.0",
-                "minimatch": "^3.0.0"
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.4"
             }
         },
         "multipipe": {
@@ -1982,10 +1990,10 @@
             "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
             "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
             "requires": {
-                "growly": "^1.3.0",
-                "semver": "^5.4.1",
-                "shellwords": "^0.1.1",
-                "which": "^1.3.0"
+                "growly": "1.3.0",
+                "semver": "5.5.0",
+                "shellwords": "0.1.1",
+                "which": "1.3.0"
             }
         },
         "node-sp-auth": {
@@ -1993,24 +2001,24 @@
             "resolved": "https://registry.npmjs.org/node-sp-auth/-/node-sp-auth-2.4.2.tgz",
             "integrity": "sha512-8s9Oa3XO1lRG8BErH8QA2DPr5uvtTO14lRl+pMdttoOyC9rvW+VQ7V8/rKmaUmtkbKw1HOFkfChcT0KWsH5HiQ==",
             "requires": {
-                "@types/bluebird": "^3.5.8",
-                "@types/cookie": "^0.1.29",
-                "@types/core-js": "^0.9.34",
-                "@types/jsonwebtoken": "^7.2.3",
-                "@types/lodash": "^4.14.69",
-                "@types/node": "^6.0.45",
-                "@types/request": "^2.47.0",
-                "@types/request-promise": "^4.1.41",
-                "bluebird": "^3.4.6",
-                "cookie": "^0.3.1",
-                "cpass": "^2.0.0",
-                "httpntlm": "^1.6.1",
-                "jsonwebtoken": "^7.4.3",
-                "lodash": "^4.17.4",
-                "node-sp-auth-config": "^2.0.2",
-                "request": "^2.75.0",
-                "request-promise": "^4.1.1",
-                "xmldoc": "^0.5.1"
+                "@types/bluebird": "3.5.20",
+                "@types/cookie": "0.1.29",
+                "@types/core-js": "0.9.46",
+                "@types/jsonwebtoken": "7.2.7",
+                "@types/lodash": "4.14.108",
+                "@types/node": "6.0.110",
+                "@types/request": "2.47.0",
+                "@types/request-promise": "4.1.41",
+                "bluebird": "3.5.1",
+                "cookie": "0.3.1",
+                "cpass": "2.0.3",
+                "httpntlm": "1.7.5",
+                "jsonwebtoken": "7.4.3",
+                "lodash": "4.17.10",
+                "node-sp-auth-config": "2.4.5",
+                "request": "2.86.0",
+                "request-promise": "4.2.2",
+                "xmldoc": "0.5.1"
             }
         },
         "node-sp-auth-config": {
@@ -2018,12 +2026,12 @@
             "resolved": "https://registry.npmjs.org/node-sp-auth-config/-/node-sp-auth-config-2.4.5.tgz",
             "integrity": "sha512-5Cx1cN1zzs1aRzbMtmkQqehNKCkSmeoa4l8cxVesiE0IX4YW9BSfyKzHOABAcnHWfFdUs7kZxMBBVT4Fuxj84w==",
             "requires": {
-                "colors": "^1.1.2",
-                "commander": "^2.14.1",
-                "cpass": "^2.0.3",
-                "inquirer": "^5.1.0",
-                "mkdirp": "^0.5.1",
-                "node-sp-auth": "^2.4.0"
+                "colors": "1.2.5",
+                "commander": "2.15.1",
+                "cpass": "2.0.3",
+                "inquirer": "5.2.0",
+                "mkdirp": "0.5.1",
+                "node-sp-auth": "2.4.2"
             }
         },
         "node.extend": {
@@ -2031,7 +2039,7 @@
             "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "requires": {
-                "is": "^3.1.0"
+                "is": "3.2.1"
             }
         },
         "normalize-path": {
@@ -2039,7 +2047,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "oauth-sign": {
@@ -2057,8 +2065,8 @@
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "requires": {
-                "for-own": "^0.1.4",
-                "is-extendable": "^0.1.1"
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
             }
         },
         "once": {
@@ -2066,7 +2074,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "onetime": {
@@ -2074,7 +2082,7 @@
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "requires": {
-                "mimic-fn": "^1.0.0"
+                "mimic-fn": "1.2.0"
             }
         },
         "ordered-read-streams": {
@@ -2082,8 +2090,8 @@
             "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
             "requires": {
-                "is-stream": "^1.0.1",
-                "readable-stream": "^2.0.1"
+                "is-stream": "1.1.0",
+                "readable-stream": "2.3.6"
             }
         },
         "os": {
@@ -2101,10 +2109,10 @@
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "requires": {
-                "glob-base": "^0.3.0",
-                "is-dotfile": "^1.0.0",
-                "is-extglob": "^1.0.0",
-                "is-glob": "^2.0.0"
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
             }
         },
         "path": {
@@ -2112,8 +2120,8 @@
             "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
             "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
             "requires": {
-                "process": "^0.11.1",
-                "util": "^0.10.3"
+                "process": "0.11.10",
+                "util": "0.10.3"
             }
         },
         "path-dirname": {
@@ -2131,7 +2139,7 @@
             "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "requires": {
-                "through": "~2.3"
+                "through": "2.3.8"
             }
         },
         "pend": {
@@ -2159,7 +2167,7 @@
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "requires": {
-                "pinkie": "^2.0.0"
+                "pinkie": "2.0.4"
             }
         },
         "plugin-error": {
@@ -2167,11 +2175,11 @@
             "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "requires": {
-                "ansi-cyan": "^0.1.1",
-                "ansi-red": "^0.1.1",
-                "arr-diff": "^1.0.1",
-                "arr-union": "^2.0.1",
-                "extend-shallow": "^1.1.2"
+                "ansi-cyan": "0.1.1",
+                "ansi-red": "0.1.1",
+                "arr-diff": "1.1.0",
+                "arr-union": "2.1.0",
+                "extend-shallow": "1.1.4"
             }
         },
         "preserve": {
@@ -2209,7 +2217,7 @@
             "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "requires": {
-                "inherits": "~2.0.0"
+                "inherits": "2.0.1"
             }
         },
         "randomatic": {
@@ -2217,9 +2225,9 @@
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
             "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "requires": {
-                "is-number": "^4.0.0",
-                "kind-of": "^6.0.0",
-                "math-random": "^1.0.1"
+                "is-number": "4.0.0",
+                "kind-of": "6.0.2",
+                "math-random": "1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -2239,13 +2247,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
             },
             "dependencies": {
                 "inherits": {
@@ -2260,7 +2268,7 @@
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "requires": {
-                "is-equal-shallow": "^0.1.3"
+                "is-equal-shallow": "0.1.3"
             }
         },
         "remove-trailing-separator": {
@@ -2288,27 +2296,27 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.86.0.tgz",
             "integrity": "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
             "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
-                "hawk": "~6.0.2",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "tough-cookie": "~2.3.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.7.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.6",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.2",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.18",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.3.4",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.2.1"
             }
         },
         "request-promise": {
@@ -2316,10 +2324,10 @@
             "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
             "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
             "requires": {
-                "bluebird": "^3.5.0",
+                "bluebird": "3.5.1",
                 "request-promise-core": "1.1.1",
-                "stealthy-require": "^1.1.0",
-                "tough-cookie": ">=2.3.3"
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.3.4"
             }
         },
         "request-promise-core": {
@@ -2327,7 +2335,7 @@
             "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
             "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
             "requires": {
-                "lodash": "^4.13.1"
+                "lodash": "4.17.10"
             }
         },
         "requires-port": {
@@ -2340,8 +2348,8 @@
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "requires": {
-                "onetime": "^2.0.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
             }
         },
         "rimraf": {
@@ -2349,7 +2357,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.2"
             },
             "dependencies": {
                 "glob": {
@@ -2357,12 +2365,12 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.1",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 }
             }
@@ -2372,7 +2380,7 @@
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "requires": {
-                "is-promise": "^2.1.0"
+                "is-promise": "2.1.0"
             }
         },
         "rxjs": {
@@ -2437,7 +2445,7 @@
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
             "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
             "requires": {
-                "hoek": "4.x.x"
+                "hoek": "4.2.1"
             },
             "dependencies": {
                 "hoek": {
@@ -2457,8 +2465,8 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
             "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
             "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
+                "buffer-from": "1.0.0",
+                "source-map": "0.6.1"
             }
         },
         "sp-request": {
@@ -2466,18 +2474,18 @@
             "resolved": "https://registry.npmjs.org/sp-request/-/sp-request-2.1.3.tgz",
             "integrity": "sha512-FEzfPecH0J6K45tZXmHaP1MeqPtourNQu/ssJxZdRjCDRCElcXMsyIoZuQuyxuhabXU//wVPWJQcOJ0zuXzuTQ==",
             "requires": {
-                "@types/bluebird": "^3.5.8",
-                "@types/core-js": "^0.9.34",
-                "@types/lodash": "^4.14.37",
-                "@types/node": "^6.0.45",
+                "@types/bluebird": "3.5.20",
+                "@types/core-js": "0.9.46",
+                "@types/lodash": "4.14.108",
+                "@types/node": "6.0.110",
                 "@types/request": "0.0.31",
-                "@types/request-promise": "^4.1.36",
-                "bluebird": "^3.5.0",
-                "httpntlm": "^1.7.5",
-                "lodash": "^4.12.0",
-                "node-sp-auth": "^2.1.1",
-                "request": "^2.81.0",
-                "request-promise": "^4.2.1"
+                "@types/request-promise": "4.1.41",
+                "bluebird": "3.5.1",
+                "httpntlm": "1.7.5",
+                "lodash": "4.17.10",
+                "node-sp-auth": "2.4.2",
+                "request": "2.86.0",
+                "request-promise": "4.2.2"
             },
             "dependencies": {
                 "@types/request": {
@@ -2485,8 +2493,8 @@
                     "resolved": "https://registry.npmjs.org/@types/request/-/request-0.0.31.tgz",
                     "integrity": "sha1-6ed2YfdsWWpv0O26YiAFZnFxuus=",
                     "requires": {
-                        "@types/form-data": "*",
-                        "@types/node": "*"
+                        "@types/form-data": "2.2.1",
+                        "@types/node": "6.0.110"
                     }
                 }
             }
@@ -2501,7 +2509,7 @@
             "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "requires": {
-                "through": "2"
+                "through": "2.3.8"
             }
         },
         "sppull": {
@@ -2509,19 +2517,10 @@
             "resolved": "https://registry.npmjs.org/sppull/-/sppull-2.2.6.tgz",
             "integrity": "sha512-7ygXhaujhgmWpOPeLhRKfxIFZevwcQN6jXM/Q6nrsV1wblvlQsWfymxwKf4bjqmaxE67CdKBZdex8jvKoi8o+Q==",
             "requires": {
-                "colors": "^1.1.2",
-                "mkdirp": "^0.5.1",
-                "node-sp-auth-config": "^2.4.5",
-                "request": "^2.83.0",
-                "sp-request": "^2.1.3"
-            }
-        },
-        "sppurge": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/sppurge/-/sppurge-1.1.4.tgz",
-            "integrity": "sha512-tCIuYwUJnIc1rCmpBdLtR3Zk5c80KidodKLTS0tihgU/OpcEwumbEyfQUoj7nVep8u0c6dPw+FuJ4dHS67H63Q==",
-            "requires": {
-                "path": "0.12.7",
+                "colors": "1.2.5",
+                "mkdirp": "0.5.1",
+                "node-sp-auth-config": "2.4.5",
+                "request": "2.86.0",
                 "sp-request": "2.1.3"
             }
         },
@@ -2530,20 +2529,20 @@
             "resolved": "https://registry.npmjs.org/spsave/-/spsave-3.1.5.tgz",
             "integrity": "sha512-QT8xs1lpShhwbyuRGfVLZ3yjdXL0pJGoHH2+7Sq7LhuGMMvWna33EY1fcBo1ppsMiMfApH8VZFZsIKED3CSqtQ==",
             "requires": {
-                "@types/bluebird": "^3.0.35",
-                "@types/core-js": "^0.9.34",
-                "@types/lodash": "^4.14.37",
-                "@types/node": "^6.0.45",
+                "@types/bluebird": "3.5.20",
+                "@types/core-js": "0.9.46",
+                "@types/lodash": "4.14.108",
+                "@types/node": "6.0.110",
                 "@types/node-notifier": "0.0.28",
-                "@types/vinyl": "^1.2.30",
+                "@types/vinyl": "1.2.30",
                 "@types/vinyl-fs": "0.0.28",
-                "bluebird": "^3.4.0",
-                "colors": "^1.2.1",
-                "globby": "^4.1.0",
-                "lodash": "^4.13.1",
-                "node-notifier": "^5.2.1",
-                "sp-request": "^2.1.0",
-                "vinyl": "^1.1.1"
+                "bluebird": "3.5.1",
+                "colors": "1.2.5",
+                "globby": "4.1.0",
+                "lodash": "4.17.10",
+                "node-notifier": "5.2.1",
+                "sp-request": "2.1.3",
+                "vinyl": "1.2.0"
             }
         },
         "sshpk": {
@@ -2551,14 +2550,14 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
             "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
             }
         },
         "stat-mode": {
@@ -2576,7 +2575,7 @@
             "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "requires": {
-                "duplexer": "~0.1.1"
+                "duplexer": "0.1.1"
             }
         },
         "stream-shift": {
@@ -2589,7 +2588,7 @@
             "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "requires": {
-                "readable-stream": "^2.0.2"
+                "readable-stream": "2.3.6"
             }
         },
         "streamifier": {
@@ -2602,8 +2601,8 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
             }
         },
         "string_decoder": {
@@ -2611,7 +2610,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
             }
         },
         "strip-ansi": {
@@ -2619,7 +2618,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
             }
         },
         "strip-bom": {
@@ -2627,7 +2626,7 @@
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "requires": {
-                "is-utf8": "^0.2.0"
+                "is-utf8": "0.2.1"
             }
         },
         "strip-bom-stream": {
@@ -2635,8 +2634,8 @@
             "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "requires": {
-                "first-chunk-stream": "^1.0.0",
-                "strip-bom": "^2.0.0"
+                "first-chunk-stream": "1.0.0",
+                "strip-bom": "2.0.0"
             }
         },
         "supports-color": {
@@ -2644,7 +2643,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
             "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
             "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
             }
         },
         "symbol-observable": {
@@ -2657,9 +2656,9 @@
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.1"
             }
         },
         "through": {
@@ -2672,8 +2671,8 @@
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "requires": {
-                "readable-stream": "^2.1.5",
-                "xtend": "~4.0.1"
+                "readable-stream": "2.3.6",
+                "xtend": "4.0.1"
             }
         },
         "through2-filter": {
@@ -2681,8 +2680,8 @@
             "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "requires": {
-                "through2": "~2.0.0",
-                "xtend": "~4.0.0"
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
             }
         },
         "time-stamp": {
@@ -2695,7 +2694,7 @@
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "requires": {
-                "os-tmpdir": "~1.0.2"
+                "os-tmpdir": "1.0.2"
             }
         },
         "to-absolute-glob": {
@@ -2703,7 +2702,7 @@
             "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "requires": {
-                "extend-shallow": "^2.0.1"
+                "extend-shallow": "2.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -2711,7 +2710,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -2727,7 +2726,7 @@
             "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
             "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
             "requires": {
-                "hoek": "2.x.x"
+                "hoek": "2.16.3"
             }
         },
         "tough-cookie": {
@@ -2735,7 +2734,7 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "requires": {
-                "punycode": "^1.4.1"
+                "punycode": "1.4.1"
             }
         },
         "tunnel-agent": {
@@ -2743,7 +2742,7 @@
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.2"
             }
         },
         "tweetnacl": {
@@ -2751,12 +2750,6 @@
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "optional": true
-        },
-        "typescript": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
-            "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
-            "dev": true
         },
         "underscore": {
             "version": "1.7.0",
@@ -2768,8 +2761,8 @@
             "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "requires": {
-                "json-stable-stringify": "^1.0.0",
-                "through2-filter": "^2.0.0"
+                "json-stable-stringify": "1.0.1",
+                "through2-filter": "2.0.0"
             }
         },
         "universalify": {
@@ -2782,8 +2775,8 @@
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
             "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
             "requires": {
-                "querystringify": "^2.0.0",
-                "requires-port": "^1.0.0"
+                "querystringify": "2.0.0",
+                "requires-port": "1.0.0"
             }
         },
         "util": {
@@ -2814,9 +2807,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             }
         },
         "vinyl": {
@@ -2824,8 +2817,8 @@
             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
             "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
             "requires": {
-                "clone": "^1.0.0",
-                "clone-stats": "^0.0.1",
+                "clone": "1.0.4",
+                "clone-stats": "0.0.1",
                 "replace-ext": "0.0.1"
             }
         },
@@ -2834,23 +2827,23 @@
             "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "requires": {
-                "duplexify": "^3.2.0",
-                "glob-stream": "^5.3.2",
-                "graceful-fs": "^4.0.0",
+                "duplexify": "3.6.0",
+                "glob-stream": "5.3.5",
+                "graceful-fs": "4.1.11",
                 "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "^0.3.0",
-                "lazystream": "^1.0.0",
-                "lodash.isequal": "^4.0.0",
-                "merge-stream": "^1.0.0",
-                "mkdirp": "^0.5.0",
-                "object-assign": "^4.0.0",
-                "readable-stream": "^2.0.4",
-                "strip-bom": "^2.0.0",
-                "strip-bom-stream": "^1.0.0",
-                "through2": "^2.0.0",
-                "through2-filter": "^2.0.0",
-                "vali-date": "^1.0.0",
-                "vinyl": "^1.0.0"
+                "is-valid-glob": "0.3.0",
+                "lazystream": "1.0.0",
+                "lodash.isequal": "4.5.0",
+                "merge-stream": "1.0.1",
+                "mkdirp": "0.5.1",
+                "object-assign": "4.1.1",
+                "readable-stream": "2.3.6",
+                "strip-bom": "2.0.0",
+                "strip-bom-stream": "1.0.0",
+                "through2": "2.0.3",
+                "through2-filter": "2.0.0",
+                "vali-date": "1.0.0",
+                "vinyl": "1.2.0"
             }
         },
         "vinyl-source-stream": {
@@ -2858,8 +2851,8 @@
             "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "requires": {
-                "through2": "^2.0.3",
-                "vinyl": "^0.4.3"
+                "through2": "2.0.3",
+                "vinyl": "0.4.6"
             },
             "dependencies": {
                 "clone": {
@@ -2872,8 +2865,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "requires": {
-                        "clone": "^0.2.0",
-                        "clone-stats": "^0.0.1"
+                        "clone": "0.2.0",
+                        "clone-stats": "0.0.1"
                     }
                 }
             }
@@ -2883,20 +2876,20 @@
             "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.17.tgz",
             "integrity": "sha512-yNMyrgEua2qyW7+trNNYhA6PeldRrBcwtLtlazkdtzcmkHMKECM/08bPF8HF2ZFuwHgD+8FQsdqd/DvJYQYjJg==",
             "requires": {
-                "glob": "^7.1.2",
-                "gulp-chmod": "^2.0.0",
-                "gulp-filter": "^5.0.1",
+                "glob": "7.1.2",
+                "gulp-chmod": "2.0.0",
+                "gulp-filter": "5.1.0",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "^0.5.0",
-                "gulp-symdest": "^1.1.0",
-                "gulp-untar": "^0.0.6",
-                "gulp-vinyl-zip": "^2.1.0",
-                "mocha": "^4.0.1",
-                "request": "^2.83.0",
-                "semver": "^5.4.1",
-                "source-map-support": "^0.5.0",
-                "url-parse": "^1.1.9",
-                "vinyl-source-stream": "^1.1.0"
+                "gulp-remote-src-vscode": "0.5.0",
+                "gulp-symdest": "1.1.0",
+                "gulp-untar": "0.0.6",
+                "gulp-vinyl-zip": "2.1.0",
+                "mocha": "4.1.0",
+                "request": "2.86.0",
+                "semver": "5.5.0",
+                "source-map-support": "0.5.6",
+                "url-parse": "1.4.0",
+                "vinyl-source-stream": "1.1.2"
             },
             "dependencies": {
                 "commander": {
@@ -2922,12 +2915,12 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.1",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "growl": {
@@ -2967,7 +2960,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "requires": {
-                        "has-flag": "^2.0.0"
+                        "has-flag": "2.0.0"
                     }
                 }
             }
@@ -2982,7 +2975,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "wrappy": {
@@ -2995,7 +2988,7 @@
             "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-0.5.1.tgz",
             "integrity": "sha1-kuQ36QDb/wRFDvrpDTyl8WVl9zg=",
             "requires": {
-                "sax": "~1.1.1"
+                "sax": "1.1.6"
             }
         },
         "xtend": {
@@ -3008,8 +3001,8 @@
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
             "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
             "requires": {
-                "buffer-crc32": "~0.2.3",
-                "fd-slicer": "~1.0.1"
+                "buffer-crc32": "0.2.13",
+                "fd-slicer": "1.0.1"
             }
         },
         "yazl": {
@@ -3017,7 +3010,7 @@
             "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "requires": {
-                "buffer-crc32": "~0.2.3"
+                "buffer-crc32": "0.2.13"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "spgo",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -2750,6 +2750,12 @@
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "optional": true
+        },
+        "typescript": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.0.tgz",
+            "integrity": "sha1-YJiedMrZPCj+Nff3tB/psgWiVwE=",
+            "dev": true
         },
         "underscore": {
             "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "o365",
         "ide"
     ],
-    "version": "1.3.0",
+    "version": "1.3.1",
     "publisher": "SiteGo",
     "icon": "assets/SiteGoLogo.png",
     "galleryBanner": {

--- a/package.json
+++ b/package.json
@@ -184,6 +184,8 @@
         "typescript": "2.5.0"
     },
     "dependencies": {
+        "@types/fs-extra": "^5.0.2",
+        "cpass": "^2.0.3",
         "fs-extra": "^4.0.3",
         "node-sp-auth": "^2.4.2",
         "parse-glob": "^3.0.4",

--- a/src/appManager.ts
+++ b/src/appManager.ts
@@ -4,7 +4,6 @@ import * as vscode from 'vscode';
 import { IConfig } from './spgo';
 import { Logger } from './util/logger';
 import { Constants } from './constants';
-import { Credential } from './model/credential';
 import { IAppManager, ICredential } from './spgo';
 import { CredentialDao } from './dao/credentialDao';
 import initializeConfiguration from './dao/configurationDao';
@@ -16,7 +15,7 @@ export class AppManager implements IAppManager {
     statusBarItem: vscode.StatusBarItem;
     
     constructor() {
-        this.credentials = new Credential('','');
+        this.credentials = null;
         this.outputChannel = vscode.window.createOutputChannel(Constants.OUTPUT_CHANNEL_NAME);
         this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 5);
 

--- a/src/appManager.ts
+++ b/src/appManager.ts
@@ -1,11 +1,12 @@
 'use strict';
 import * as vscode from 'vscode';
 
-import {IConfig} from './spgo';
-import {Logger} from './util/logger';
-import {Constants} from './constants';
-import {Credential} from './model/credential';
-import {IAppManager, ICredential} from './spgo';
+import { IConfig } from './spgo';
+import { Logger } from './util/logger';
+import { Constants } from './constants';
+import { Credential } from './model/credential';
+import { IAppManager, ICredential } from './spgo';
+import { CredentialDao } from './dao/credentialDao';
 import initializeConfiguration from './dao/configurationDao';
 
 export class AppManager implements IAppManager {
@@ -21,6 +22,10 @@ export class AppManager implements IAppManager {
 
         //initialize Configuration file
         initializeConfiguration(this).then(()=> {
+            //stored credentials?
+            if(this.config.storeCredentials){
+                this.credentials = CredentialDao.getCredentials(this.config.sharePointSiteUrl);
+            }
             this.statusBarItem.text = 'SPGo enabled';
         }).catch(err => {
             Logger.showError('SPGo: Missing Configuration');

--- a/src/command/checkOutFile.ts
+++ b/src/command/checkOutFile.ts
@@ -1,58 +1,64 @@
 'use strict';
 import * as os from 'os';
 import * as path from 'path';
+import * as fs from 'fs-extra';
 import * as vscode from 'vscode';
 
 
-import {Logger} from '../util/logger';
-import {Constants} from './../constants';
-import {UiHelper} from './../util/uiHelper';
-import {FileHelper} from './../util/fileHelper';
-import {SPFileService} from './../service/spFileService';
-import {AuthenticationService} from './../service/authenticationService';
+import { Logger } from '../util/logger';
+import { Constants } from './../constants';
+import { UiHelper } from './../util/uiHelper';
+import { FileHelper } from './../util/fileHelper';
+import { SPFileService } from './../service/spFileService';
+import { AuthenticationService } from './../service/authenticationService';
 import { ErrorHelper } from '../util/errorHelper';
 
 export default function checkOutFile(fileUri: vscode.Uri) : Thenable<any> {
 
-    if( fileUri.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
-        let downloadPath : string = os.tmpdir() + path.sep + Constants.TEMP_FOLDER;
-        let fileName : string = FileHelper.getFileName(fileUri.path);
-        let fileService : SPFileService = new SPFileService();
+    //is this a directory?
+    if(fs.lstatSync(fileUri.fsPath).isDirectory()){
+        Logger.showWarning('The check-out file command only works for single files at this time.')
+    }
+    else{
+        if( fileUri.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
+            let downloadPath : string = os.tmpdir() + path.sep + Constants.TEMP_FOLDER;
+            let fileName : string = FileHelper.getFileName(fileUri.fsPath);
+            let fileService : SPFileService = new SPFileService();
 
-        Logger.outputMessage(`Checking out File:  ${fileUri.path}`, vscode.window.spgo.outputChannel);
+            Logger.outputMessage(`Checking out File:  ${fileUri.fsPath}`, vscode.window.spgo.outputChannel);
 
-        return UiHelper.showStatusBarProgress(`Checking out File:  ${fileName}`,
-            AuthenticationService.verifyCredentials(vscode.window.spgo, fileUri)
-                .then((filePath) => fileService.checkoutFile(filePath))
-                .then(() => downloadFileAndCompare(fileUri, downloadPath))
-                .catch(err => ErrorHelper.handleError(err))
-        );
+            return UiHelper.showStatusBarProgress(`Checking out File:  ${fileName}`,
+                AuthenticationService.verifyCredentials(vscode.window.spgo, fileUri)
+                    .then((filePath) => fileService.checkoutFile(filePath))
+                    .then(() => downloadFileAndCompare(fileUri, downloadPath))
+                    .catch(err => ErrorHelper.handleError(err))
+            );
+            
+            function downloadFileAndCompare(localPath : vscode.Uri, downloadPath : any){
 
-        
-        function downloadFileAndCompare(localPath : vscode.Uri, downloadPath : any){
-
-            fileService.downloadFileMajorVersion(localPath, downloadPath)
-                .then((dlFileUrl) => {
-                    //open files - a bit messy, but necessary for working with async objects
-                    vscode.workspace.openTextDocument(localPath)
-                        .then((doc1) => {
-                            let remotePath : vscode.Uri = vscode.Uri.parse('file:///' + dlFileUrl[0].SavedToLocalPath);
-                            
-                            vscode.workspace.openTextDocument(remotePath)
-                                .then((doc2) => {
-                                    if(doc1.getText() != doc2.getText()){
-                                        vscode.window.showInformationMessage('The server version of this file appears to be different from your local version. Open both files in a compare window?', Constants.OPTIONS_OPEN)
-                                            .then(result => {
-                                                if( result == Constants.OPTIONS_OPEN){
-                                                    Logger.outputMessage(`localPath:  ${localPath} dlFilrUrl: ${remotePath}`, vscode.window.spgo.outputChannel);
-                                                    vscode.commands.executeCommand('vscode.diff', remotePath, localPath, '(Server)  <=====>  (Local)');
-                                                }
-                                            });
-                                    }
-                                });
-                        },
-                        (err) => {ErrorHelper.handleError(err);});
-                })
+                fileService.downloadFileMajorVersion(localPath, downloadPath)
+                    .then((dlFileUrl) => {
+                        //open files - a bit messy, but necessary for working with async objects
+                        vscode.workspace.openTextDocument(localPath)
+                            .then((doc1) => {
+                                let remotePath : vscode.Uri = vscode.Uri.parse('file:///' + dlFileUrl[0].SavedToLocalPath);
+                                
+                                vscode.workspace.openTextDocument(remotePath)
+                                    .then((doc2) => {
+                                        if(doc1.getText() != doc2.getText()){
+                                            vscode.window.showInformationMessage('The server version of this file appears to be different from your local version. Open both files in a compare window?', Constants.OPTIONS_OPEN)
+                                                .then(result => {
+                                                    if( result == Constants.OPTIONS_OPEN){
+                                                        Logger.outputMessage(`localPath:  ${localPath} dlFilrUrl: ${remotePath}`, vscode.window.spgo.outputChannel);
+                                                        vscode.commands.executeCommand('vscode.diff', remotePath, localPath, '(Server)  <=====>  (Local)');
+                                                    }
+                                                });
+                                        }
+                                    });
+                            },
+                            (err) => {ErrorHelper.handleError(err);});
+                    })
+            }
         }
     }
 }

--- a/src/command/compareFileWithServer.ts
+++ b/src/command/compareFileWithServer.ts
@@ -1,38 +1,44 @@
 'use strict';
 import * as os from 'os';
 import * as path from 'path';
+import * as fs from 'fs-extra';
 import * as vscode from 'vscode';
 
-import {Logger} from '../util/logger';
-import {Constants} from './../constants';
-import {UiHelper} from './../util/uiHelper';
-import {UrlHelper} from './../util/urlHelper';
-import {FileHelper} from './../util/fileHelper';
-import {ErrorHelper} from '../util/errorHelper';
-import {SPFileService} from './../service/spFileService';
-import {AuthenticationService} from './../service/authenticationService';
+import { Logger } from '../util/logger';
+import { Constants } from './../constants';
+import { UiHelper } from './../util/uiHelper';
+import { UrlHelper } from './../util/urlHelper';
+import { FileHelper } from './../util/fileHelper';
+import { ErrorHelper } from '../util/errorHelper';
+import { SPFileService } from './../service/spFileService';
+import { AuthenticationService } from './../service/authenticationService';
 
 export default function compareFileWithServer(localPath : vscode.Uri) : Thenable<any> {
+    //is this a directory?
+    if(fs.lstatSync(localPath.fsPath).isDirectory()){
+        Logger.showWarning('The compare file with server command only works for single files at this time.')
+    }
+    else{
+        if( localPath.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
+            let fileName : string = FileHelper.getFileName(localPath.fsPath);
+            let fileService : SPFileService = new SPFileService();
+            let downloadPath : string = os.tmpdir() + path.sep + Constants.TEMP_FOLDER;
 
-    if( localPath.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
-        let fileName : string = FileHelper.getFileName(localPath.path);
-        let fileService : SPFileService = new SPFileService();
-        let downloadPath : string = os.tmpdir() + path.sep + Constants.TEMP_FOLDER;
+            Logger.outputMessage(`Starting file compare for:  ${fileName}`, vscode.window.spgo.outputChannel);
+            
+            return UiHelper.showStatusBarProgress(`Downloading Server version of:  ${fileName}`,
+                AuthenticationService.verifyCredentials(vscode.window.spgo, localPath)
+                    .then((localPath) => fileService.downloadFileMajorVersion(localPath, downloadPath))
+                    .then((dlFileUrl) => openFileCompare(localPath, dlFileUrl))
+                    .catch(err => ErrorHelper.handleError(err))
+            );
 
-        Logger.outputMessage(`Starting file compare for:  ${fileName}`, vscode.window.spgo.outputChannel);
-        
-        return UiHelper.showStatusBarProgress(`Downloading Server version of:  ${fileName}`,
-            AuthenticationService.verifyCredentials(vscode.window.spgo, localPath)
-                .then((localPath) => fileService.downloadFileMajorVersion(localPath, downloadPath))
-                .then((dlFileUrl) => openFileCompare(localPath, dlFileUrl))
-                .catch(err => ErrorHelper.handleError(err))
-        );
+            function openFileCompare(localPath : vscode.Uri, dlFileUrl : any){            
+                let remotePath : vscode.Uri = vscode.Uri.parse('file:///' + UrlHelper.removeLeadingSlash(dlFileUrl[0].SavedToLocalPath));
+                Logger.outputMessage(`localPath:  ${localPath} dlFilrUrl: ${remotePath}`, vscode.window.spgo.outputChannel);
 
-        function openFileCompare(localPath : vscode.Uri, dlFileUrl : any){            
-            let remotePath : vscode.Uri = vscode.Uri.parse('file:///' + UrlHelper.removeLeadingSlash(dlFileUrl[0].SavedToLocalPath));
-            Logger.outputMessage(`localPath:  ${localPath} dlFilrUrl: ${remotePath}`, vscode.window.spgo.outputChannel);
-
-            vscode.commands.executeCommand('vscode.diff', remotePath, localPath, '(Server)  <=====>  (Local)');
+                vscode.commands.executeCommand('vscode.diff', remotePath, localPath, '(Server)  <=====>  (Local)');
+            }
         }
     }
 }

--- a/src/command/configureWorkspace.ts
+++ b/src/command/configureWorkspace.ts
@@ -4,7 +4,8 @@ import * as fs from 'fs-extra';
 import * as vscode from 'vscode';
 import { ErrorHelper } from '../util/errorHelper';
 
-import {Constants} from './../constants';
+import { Constants } from './../constants';
+import { UrlHelper } from '../util/urlHelper';
 import initializeConfiguration from './../dao/configurationDao';
 
 export default function configureWorkspace() {
@@ -33,7 +34,7 @@ export default function configureWorkspace() {
                         siteUrl = 'https://' + siteUrl;
                     }
 
-                    config.sharePointSiteUrl = siteUrl.toString() || config.sharePointSiteUrl || '';
+                    config.sharePointSiteUrl = UrlHelper.removeTrailingSlash(siteUrl.toString() || config.sharePointSiteUrl || '');
 
                     if (!config.sharePointSiteUrl) { 
                         reject('SharePoint site Url is required'); 

--- a/src/command/discardCheckOut.ts
+++ b/src/command/discardCheckOut.ts
@@ -1,4 +1,5 @@
 'use strict';
+import * as fs from 'fs-extra';
 import * as vscode from 'vscode';
 
 import {Logger} from '../util/logger';
@@ -10,19 +11,25 @@ import {AuthenticationService} from './../service/authenticationService';
 
 export default function discardCheckOut(fileUri: vscode.Uri) : Thenable<any> {
 
-    if( fileUri.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
-        let fileName : string = FileHelper.getFileName(fileUri.path);
-        let fileService : SPFileService = new SPFileService();
+    //is this a directory?
+    if(fs.lstatSync(fileUri.fsPath).isDirectory()){
+        Logger.showWarning('The discard file check-out command only works for single files at this time.')
+    }
+    else{
+        if( fileUri.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
+            let fileName : string = FileHelper.getFileName(fileUri.fsPath);
+            let fileService : SPFileService = new SPFileService();
 
-        Logger.outputMessage(`Discarding Check out for File:  ${fileUri.path}`, vscode.window.spgo.outputChannel);
-        
-        return UiHelper.showStatusBarProgress(`Discarding Check out for:  ${fileName}`,
-            AuthenticationService.verifyCredentials(vscode.window.spgo, fileUri)
-                .then((filePath) => fileService.undoFileCheckout(filePath))
-                .then(() => {
-                    Logger.outputMessage(`Discard check-out successful for file ${fileUri.path}.`, vscode.window.spgo.outputChannel);
-                })
-                .catch(err => ErrorHelper.handleError(err))
-        );
+            Logger.outputMessage(`Discarding Check out for File:  ${fileUri.fsPath}`, vscode.window.spgo.outputChannel);
+            
+            return UiHelper.showStatusBarProgress(`Discarding Check out for:  ${fileName}`,
+                AuthenticationService.verifyCredentials(vscode.window.spgo, fileUri)
+                    .then((filePath) => fileService.undoFileCheckout(filePath))
+                    .then(() => {
+                        Logger.outputMessage(`Discard check-out successful for file ${fileUri.fsPath}.`, vscode.window.spgo.outputChannel);
+                    })
+                    .catch(err => ErrorHelper.handleError(err))
+            );
+        }
     }
 }

--- a/src/command/getCurrentFileInformation.ts
+++ b/src/command/getCurrentFileInformation.ts
@@ -18,7 +18,7 @@ export default function saveFile(textDocument: vscode.TextDocument) : Thenable<a
             AuthenticationService.verifyCredentials(vscode.window.spgo, textDocument)
                 .then((textDocument) => fileService.getFileInformation(textDocument))
                 .then((fileInfo) => showFileInformation(fileInfo))
-                .catch(err => ErrorHelper.handleError(err))
+                .catch(err => ErrorHelper.handleError(err, true))
         );
     }
 

--- a/src/command/publishFile.ts
+++ b/src/command/publishFile.ts
@@ -1,28 +1,43 @@
 'use strict';
+import * as path from 'path';
+import * as fs from 'fs-extra';
 import * as vscode from 'vscode';
 
-import {Logger} from '../util/logger';
-import {Constants} from './../constants';
-import {IPublishingAction} from './../spgo';
-import {UiHelper} from './../util/uiHelper';
-import {FileHelper} from './../util/fileHelper';
-import {ErrorHelper} from './../util/errorHelper';
-import {SPFileService} from './../service/spFileService';
-import {AuthenticationService} from './../service/authenticationService';
+import { Logger } from '../util/logger';
+import { Constants } from './../constants';
+import { IPublishingAction } from './../spgo';
+import { UiHelper } from './../util/uiHelper';
+import { UrlHelper } from '../util/urlHelper';
+import { FileHelper } from './../util/fileHelper';
+import { ErrorHelper } from './../util/errorHelper';
+import { SPFileService } from './../service/spFileService';
+import { AuthenticationService } from './../service/authenticationService';
 
 
 export default function publishFile(fileUri: vscode.Uri, publishingScope : string) : Thenable<any> {
 
     if( fileUri.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
-        let fileName : string = FileHelper.getFileName(fileUri.path);
+        let publishingInfo : IPublishingAction = null;
         let fileService : SPFileService = new SPFileService();
-        let publishingInfo : IPublishingAction = {
-            fileUri : fileUri,
-            scope : publishingScope,
-            message : vscode.window.spgo.config.checkInMessage || Constants.PUBLISHING_DEFAULT_MESSAGE
-        }
+        let fileName : string = FileHelper.getFileName(fileUri.fsPath);
 
-        Logger.outputMessage(`Publishing ${publishingScope} file version:  ${fileUri.path}`, vscode.window.spgo.outputChannel);
+        //is this a directory?
+        if(fs.lstatSync(fileUri.fsPath).isDirectory()){
+            publishingInfo = {
+                contentUri : fileUri.fsPath + path.sep + UrlHelper.osAwareGlobStar(),
+                scope : publishingScope,
+                message : vscode.window.spgo.config.checkInMessage || Constants.PUBLISHING_DEFAULT_MESSAGE
+            }
+        }
+        else{
+            publishingInfo = {
+                contentUri : fileUri.fsPath,
+                scope : publishingScope,
+                message : vscode.window.spgo.config.checkInMessage || Constants.PUBLISHING_DEFAULT_MESSAGE
+            }
+        }
+        
+        Logger.outputMessage(`Publishing ${publishingScope} file version:  ${fileUri.fsPath}`, vscode.window.spgo.outputChannel);
         
         return UiHelper.showStatusBarProgress(`Publishing ${publishingScope} file version:  ${fileName}`,
             AuthenticationService.verifyCredentials(vscode.window.spgo, publishingInfo)

--- a/src/command/publishWorkspace.ts
+++ b/src/command/publishWorkspace.ts
@@ -1,17 +1,18 @@
 'use strict';
 import * as vscode from 'vscode';
 
-import {Logger} from '../util/logger';
-import {Constants} from './../constants';
-import {IPublishingAction} from './../spgo';
-import {UiHelper} from './../util/uiHelper';
+import { Logger } from '../util/logger';
+import { Constants } from './../constants';
+import { UrlHelper } from '../util/urlHelper';
+import { IPublishingAction } from './../spgo';
+import { UiHelper } from './../util/uiHelper';
 import { ErrorHelper } from '../util/errorHelper';
-import {SPFileService} from './../service/spFileService';
-import {AuthenticationService} from './../service/authenticationService';
+import { SPFileService } from './../service/spFileService';
+import { AuthenticationService } from './../service/authenticationService';
 
 export default function publishWorkspace() : Thenable<any> {
     let publishingInfo : IPublishingAction = {
-        fileUri : null,
+        contentUri : vscode.window.spgo.config.publishWorkspaceGlobPattern ? UrlHelper.ensureLeadingSlash(vscode.window.spgo.config.publishWorkspaceGlobPattern) : vscode.window.spgo.config.workspaceRoot + UrlHelper.osAwareGlobStar(),
         scope : Constants.PUBLISHING_MAJOR,
         message : vscode.window.spgo.config.checkInMessage || Constants.PUBLISHING_DEFAULT_MESSAGE
     }
@@ -21,7 +22,7 @@ export default function publishWorkspace() : Thenable<any> {
     return UiHelper.showStatusBarProgress('Publishing workspace', 
         AuthenticationService.verifyCredentials(vscode.window.spgo, publishingInfo)
             .then((publishingInfo) => UiHelper.getPublishingMessage(publishingInfo))
-            .then((publishingInfo) => fileService.uploadWorkspaceToServer(publishingInfo))
+            .then((publishingInfo) => fileService.uploadFilesToServer(publishingInfo))
             .catch(err => ErrorHelper.handleError(err))
     );
 }

--- a/src/command/resetCredentials.ts
+++ b/src/command/resetCredentials.ts
@@ -2,12 +2,18 @@
 import * as vscode from 'vscode';
 
 import { ErrorHelper } from '../util/errorHelper';
-import {AuthenticationService} from './../service/authenticationService';
+import { AuthenticationService } from './../service/authenticationService';
+import { CredentialDao } from '../dao/credentialDao';
 
 //Reset the Current user's Credentials.
 export default function resetCredentials() : Promise<any> {
     vscode.window.spgo.credentials = null;
 
+    //clear stored credentials
+    if(vscode.window.spgo.config.storeCredentials){
+        CredentialDao.deleteCredentials(vscode.window.spgo.config.sharePointSiteUrl);
+    }
+
     return AuthenticationService.verifyCredentials(vscode.window.spgo)
-    .catch(err => ErrorHelper.handleError(err));
+        .catch(err => ErrorHelper.handleError(err));
 }

--- a/src/command/resetCredentials.ts
+++ b/src/command/resetCredentials.ts
@@ -6,7 +6,7 @@ import {AuthenticationService} from './../service/authenticationService';
 
 //Reset the Current user's Credentials.
 export default function resetCredentials() : Promise<any> {
-    vscode.window.spgo.credential = null;
+    vscode.window.spgo.credentials = null;
 
     return AuthenticationService.verifyCredentials(vscode.window.spgo)
     .catch(err => ErrorHelper.handleError(err));

--- a/src/command/saveFile.ts
+++ b/src/command/saveFile.ts
@@ -1,27 +1,28 @@
 'use strict';
 import * as vscode from 'vscode';
 
-import {Logger} from '../util/logger';
-import {Constants} from './../constants';
-import {IPublishingAction} from './../spgo';
-import {UiHelper} from './../util/uiHelper';
-import {FileHelper} from './../util/fileHelper';
+import { Logger } from '../util/logger';
+import { Constants } from './../constants';
+import { IPublishingAction } from './../spgo';
+import { UiHelper } from './../util/uiHelper';
+import { FileHelper } from './../util/fileHelper';
 import { ErrorHelper } from '../util/errorHelper';
-import {SPFileService} from './../service/spFileService';
-import {AuthenticationService} from './../service/authenticationService';
+import { SPFileService } from './../service/spFileService';
+import { AuthenticationService } from './../service/authenticationService';
 
 export default function saveFile(fileUri: vscode.Uri) : Thenable<any> { 
 
     if( fileUri.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
-        let fileName : string = FileHelper.getFileName(fileUri.path);
+        let fileName : string = FileHelper.getFileName(fileUri.fsPath);
         let fileService : SPFileService = new SPFileService();
+        
         let publishAction : IPublishingAction = {
-            fileUri : fileUri,
+            contentUri : fileUri.fsPath,
             scope : null,
             message : vscode.window.spgo.config.checkInMessage || Constants.PUBLISHING_DEFAULT_MESSAGE
         }
         
-        Logger.outputMessage(`Saving file:  ${fileUri.path}`, vscode.window.spgo.outputChannel);
+        Logger.outputMessage(`Saving file:  ${fileUri.fsPath}`, vscode.window.spgo.outputChannel);
 
         return UiHelper.showStatusBarProgress(`Saving file:  ${fileName}`,
             AuthenticationService.verifyCredentials(vscode.window.spgo, publishAction)

--- a/src/converter/globToCamlConverter.ts
+++ b/src/converter/globToCamlConverter.ts
@@ -31,11 +31,14 @@ export class GlobToCamlConverter {
                     camlQuery = this.queryEqual(this.getFieldRef, glob.path.basename);
                 }
             }
+        }
 
-            //check to see if this is a single folder or not
-            if((!glob.is.globstar || glob.path.basename ==='*.*') && camlQuery != ''){
-                camlQuery = this.combineAnd(this.queryEqual(this.getFileDirRef, spSitePath + glob.base), camlQuery );
-            }
+        //check for folder scope
+        if(!glob.is.globstar && camlQuery != ''){
+            camlQuery = this.combineAnd(this.queryEqual(this.getFileDirRef, spSitePath + glob.base), camlQuery );
+        }
+        else if(glob.is.globstar && camlQuery != ''){
+            camlQuery = this.combineAnd(this.queryLike(this.getFileDirRef, spSitePath + glob.base), camlQuery );
         }
         
         return camlQuery;

--- a/src/converter/globToCamlConverter.ts
+++ b/src/converter/globToCamlConverter.ts
@@ -33,7 +33,7 @@ export class GlobToCamlConverter {
             }
 
             //check to see if this is a single folder or not
-            if(!glob.is.globstar && camlQuery != ''){
+            if((!glob.is.globstar || glob.path.basename ==='*.*') && camlQuery != ''){
                 camlQuery = this.combineAnd(this.queryEqual(this.getFileDirRef, spSitePath + glob.base), camlQuery );
             }
         }

--- a/src/dao/configurationDao.ts
+++ b/src/dao/configurationDao.ts
@@ -7,6 +7,7 @@ import { IConfig } from './../spgo';
 import {IAppManager} from './../spgo';
 import {Logger} from '../util/logger';
 import {Constants} from './../constants';
+import { UrlHelper } from '../util/urlHelper';
 
 export default function initializeConfiguration(appManager?: IAppManager): Promise<IConfig> {
 	return new Promise(function (resolve, reject) {
@@ -28,16 +29,19 @@ export default function initializeConfiguration(appManager?: IAppManager): Promi
 						self.config.workspaceRoot = `${vscode.workspace.rootPath}${path.sep}${self.config.sourceDirectory}`;
 					}
 					else{
-						Logger.outputMessage(err);
+						Logger.outputMessage("Config file does not exist, creating now.\r" + err);
 						//create the file
 						fs.ensureFileSync(configFilePath);
 						// hydrate self.config
 						self.config = self.config || {};
 					}
 
+					//Clean up any possible input issues
 					if (typeof self.config === 'object' && !self.config.sourceDirectory) {
 						self.config.sourceDirectory = 'src';
 					}
+					//Remove the trailing slash if a user enters one, e.g. https://tennant.sharepoint.com/sites/mysite/
+					self.config.sharePointSiteUrl = UrlHelper.removeTrailingSlash(self.config.sharePointSiteUrl);
 		
 					resolve(self.config);
 				} 

--- a/src/dao/credentialDao.ts
+++ b/src/dao/credentialDao.ts
@@ -5,21 +5,34 @@ import * as fs from 'fs-extra';
 
 import { Cpass } from 'cpass';
 import { ICredential } from '../spgo';
+import { Logger } from '../util/logger';
 import { Constants } from '../constants';
 import { UrlHelper } from '../util/urlHelper';
 
 export class CredentialDao {
+
+    static deleteCredentials(name : string){
+        fs.removeSync(name);
+    }
+
     static getCredentials(name : string) : ICredential{
         const cpass = new Cpass();
         let fileName = UrlHelper.formatUriAsFileName(name);
         let credentialFilePath : string = os.tmpdir() + path.sep + Constants.TEMP_FOLDER + path.sep + fileName + '.json';
-        let retrievedCredentials : ICredential = fs.readJsonSync(credentialFilePath);
+        let retrievedCredentials : ICredential = null;
 
-        retrievedCredentials.username = cpass.decode(retrievedCredentials.username);
-        retrievedCredentials.password = cpass.decode(retrievedCredentials.password);
-        
-        if( retrievedCredentials.domain){
-            retrievedCredentials.domain = cpass.encode(retrievedCredentials.domain)
+        try{
+            retrievedCredentials = fs.readJsonSync(credentialFilePath);
+
+            retrievedCredentials.username = cpass.decode(retrievedCredentials.username);
+            retrievedCredentials.password = cpass.decode(retrievedCredentials.password);
+            
+            if( retrievedCredentials.domain){
+                retrievedCredentials.domain = cpass.encode(retrievedCredentials.domain)
+            }
+        }
+        catch(err){
+            Logger.outputError(err);
         }
 
         return retrievedCredentials;

--- a/src/dao/credentialDao.ts
+++ b/src/dao/credentialDao.ts
@@ -1,0 +1,44 @@
+'use strict';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+
+import { Cpass } from 'cpass';
+import { ICredential } from '../spgo';
+import { Constants } from '../constants';
+import { UrlHelper } from '../util/urlHelper';
+
+export class CredentialDao {
+    static getCredentials(name : string) : ICredential{
+        const cpass = new Cpass();
+        let fileName = UrlHelper.formatUriAsFileName(name);
+        let credentialFilePath : string = os.tmpdir() + path.sep + Constants.TEMP_FOLDER + path.sep + fileName + '.json';
+        let retrievedCredentials : ICredential = fs.readJsonSync(credentialFilePath);
+
+        retrievedCredentials.username = cpass.decode(retrievedCredentials.username);
+        retrievedCredentials.password = cpass.decode(retrievedCredentials.password);
+        
+        if( retrievedCredentials.domain){
+            retrievedCredentials.domain = cpass.encode(retrievedCredentials.domain)
+        }
+
+        return retrievedCredentials;
+    }
+
+    static setCredentials( name : string, credentials : ICredential){
+        const cpass = new Cpass();
+        let fileName = UrlHelper.formatUriAsFileName(name);
+        let credentialFilePath : string = os.tmpdir() + path.sep + Constants.TEMP_FOLDER + path.sep + fileName + '.json';
+
+        let storedCredentials : ICredential = {
+            username : cpass.encode(credentials.username),
+            password : cpass.encode(credentials.password)
+        }
+
+        if( credentials.domain){
+            storedCredentials.domain = cpass.encode(credentials.domain)
+        }
+
+        fs.outputJsonSync(credentialFilePath, storedCredentials);
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,12 +105,12 @@ export function activate(context: vscode.ExtensionContext): any {
      //Download the contents of a SharePoint folder (and subfolders) to your local workspace.
      context.subscriptions.push(vscode.commands.registerCommand('spgo.reloadConfiguration', () => {
         initializeConfiguration(vscode.window.spgo)
-                    .then(function() {
-                        Logger.updateStatusBar('Configuration file reloaded', 5);
-                    })
-                    .catch(function(err : SPGo.IError) {
-                        Logger.showError(err.message, err);
-                    });
+            .then(function() {
+                Logger.updateStatusBar('Configuration file reloaded', 5);
+            })
+            .catch(function(err : SPGo.IError) {
+                Logger.showError(err.message, err);
+            });
     }));
 
     //Reset the current user's SharePoint credentials

--- a/src/gateway/spFileGateway.ts
+++ b/src/gateway/spFileGateway.ts
@@ -115,7 +115,8 @@ export class SPFileGateway{
                     })
                     .catch((err) => reject(err));
                 })
-        });
+                .catch((err) => reject(err));
+        })
     }
 
     public undoCheckOutFile(fileUri : Uri, spr : ISPRequest ) : Promise<any>{

--- a/src/service/spFileService.ts
+++ b/src/service/spFileService.ts
@@ -131,7 +131,7 @@ export class SPFileService{
             var credentials = RequestHelper.createCredentials(vscode.window.spgo);
 
             var fileOptions = {
-                glob : publishingInfo.fileUri.fsPath,
+                glob : publishingInfo.contentUri,
                 base : localFilePath,
                 folder: '/'
             };
@@ -143,20 +143,20 @@ export class SPFileService{
 
             spsave(coreOptions, credentials, fileOptions)
                 .then(function(response){
-                    Logger.outputMessage(`file ${publishingInfo.fileUri.fsPath} successfully saved to server.`, vscode.window.spgo.outputChannel);
+                    Logger.outputMessage(`file ${publishingInfo.contentUri} successfully saved to server.`, vscode.window.spgo.outputChannel);
                     resolve(response);
                 })
                 .catch((err) => reject(err));
         });
     }
 
-    public uploadWorkspaceToServer(publishingInfo : IPublishingAction) : Promise<vscode.TextDocument> {
+    public uploadFilesToServer(publishingInfo : IPublishingAction) : Promise<vscode.TextDocument> {
         return new Promise((resolve, reject) => {
             let localFilePath = vscode.window.spgo.config.workspaceRoot;
             var coreOptions = this.buildCoreUploadOptions(publishingInfo);
             var credentials = RequestHelper.createCredentials(vscode.window.spgo);
             var fileOptions = {
-                glob : localFilePath + (vscode.window.spgo.config.publishWorkspaceGlobPattern ? UrlHelper.ensureLeadingSlash(vscode.window.spgo.config.publishWorkspaceGlobPattern) : '/**/*.*'),
+                glob : publishingInfo.contentUri,
                 base : localFilePath,
                 folder: '/'
             };

--- a/src/spgo.ts
+++ b/src/spgo.ts
@@ -8,7 +8,7 @@ declare module 'vscode' {
 }
 
 export interface IAppManager{  
-    credential? : ICredential;
+    credentials? : ICredential;
     config? : IConfig;
     outputChannel: vscode.OutputChannel;
     statusBarItem: vscode.StatusBarItem;
@@ -29,6 +29,7 @@ export interface IConfig{
     remoteFolders? : string[];
     sharePointSiteUrl? : string;
     sourceDirectory? : string;      // The relative directory structure underneath the VSCode local workspace root directory
+    storeCredentials? : Boolean;
     workspaceRoot? : string;        // (internal) The full path to the local workspace root (VS Workspace root + sourceDirectory)
 }
 

--- a/src/spgo.ts
+++ b/src/spgo.ts
@@ -45,7 +45,7 @@ export interface ISPFileInformation{
 }
 
 export interface IPublishingAction{
-    fileUri: vscode.Uri;
+    contentUri: string;
     scope : string;
     message : string;
 }

--- a/src/util/errorHelper.ts
+++ b/src/util/errorHelper.ts
@@ -9,8 +9,8 @@ export class ErrorHelper{
     static handleError(err){
 
         //HACK: Come up with a better way to detect if this error was due to credentials
-        if(err.message && err.message.indexOf('wst:FailedAuthentication') > 0){
-            vscode.window.spgo.credential = null;
+        if(err.message && (err.message.indexOf('wst:FailedAuthentication') >= 0 || err.message.indexOf('Unable to resolve namespace authentiation type') >= 0)){
+            vscode.window.spgo.credentials = null;
             let error : IError ={
                 message : 'Invalid user credentials. Please reset your credentials via the command menu and try again.' 
             };

--- a/src/util/errorHelper.ts
+++ b/src/util/errorHelper.ts
@@ -6,29 +6,35 @@ import {Logger} from '../util/logger';
 
 export class ErrorHelper{
 
-    static handleError(err){
+    static handleError(err, suppressError? : Boolean){
 
-        //HACK: Come up with a better way to detect if this error was due to credentials
-        if(err.message && (err.message.indexOf('wst:FailedAuthentication') >= 0 || err.message.indexOf('Unable to resolve namespace authentiation type') >= 0)){
-            vscode.window.spgo.credentials = null;
-            let error : IError ={
-                message : 'Invalid user credentials. Please reset your credentials via the command menu and try again.' 
-            };
-            Logger.showError(error.message, err);
+        if(suppressError){
+            Logger.outputError(err, vscode.window.spgo.outputChannel);
         }
-        //otherwise something else happened.
         else{
-            if(err.message && err.message.value){
-                Logger.showError(err.message.value, err);
+            //HACK: Come up with a better way to detect if this error was due to credentials
+            if(err.message && (err.message.indexOf('wst:FailedAuthentication') >= 0 || err.message.indexOf('Unable to resolve namespace authentiation type') >= 0)){
+                vscode.window.spgo.credentials = null;
+                let error : IError ={
+                    message : 'Invalid user credentials. Please reset your credentials via the command menu and try again.' 
+                };
+                Logger.showError(error.message, err);
             }
-            // log sharepoint errors
-            else if(err.error && err.error.error ){
-                Logger.showError(err.error.error.message.value, err);
-            }
+            //otherwise something else happened.
             else{
-                Logger.outputError(err, vscode.window.spgo.outputChannel);
-            }
+                if(err.message && err.message.value){
+                    Logger.showError(err.message.value, err);
+                }
+                // log sharepoint errors
+                else if(err.error && err.error.error ){
+                    Logger.showError(err.error.error.message.value, err);
+                }
+                else{
+                    Logger.outputError(err, vscode.window.spgo.outputChannel);
+                }
+            }  
         }
+        
     }
 
     // static handleErrorSilently(err, reject){

--- a/src/util/requestHelper.ts
+++ b/src/util/requestHelper.ts
@@ -16,8 +16,8 @@ export class RequestHelper {
         switch(appManager.config.authenticationType){
             case Constants.SECURITY_ADFS:{
                 let credentials : IAdfsUserCredentials = {
-                    password: appManager.credential.password,
-                    username: appManager.credential.username,
+                    password: appManager.credentials.password,
+                    username: appManager.credentials.username,
                     relyingParty: appManager.config.authenticationDetails.relayingParty,
                     adfsUrl: appManager.config.authenticationDetails.adfsUrl
                 };
@@ -26,16 +26,16 @@ export class RequestHelper {
             }
             case Constants.SECURITY_DIGEST: {
                 let credentials : IUserCredentials = {
-                    password: appManager.credential.password,
-                    username: appManager.credential.username
+                    password: appManager.credentials.password,
+                    username: appManager.credentials.username
                 };
                 
                 return credentials;
             }
             case Constants.SECURITY_FORMS: {
                 let credentials : IOnpremiseFbaCredentials = {
-                    password: appManager.credential.password,
-                    username: appManager.credential.username,
+                    password: appManager.credentials.password,
+                    username: appManager.credentials.username,
                     fba: true
                   };
                 
@@ -43,11 +43,11 @@ export class RequestHelper {
             }
             case Constants.SECURITY_NTLM: {
                 let credentials : IOnpremiseUserCredentials ;
-                let parts : string[] = appManager.credential.username.split('\\');
+                let parts : string[] = appManager.credentials.username.split('\\');
                 if (parts.length > 1) {
                     credentials = {
                         domain : parts[0],
-                        password : appManager.credential.password,
+                        password : appManager.credentials.password,
                         username : parts[1]
                     }
                 }
@@ -56,8 +56,8 @@ export class RequestHelper {
             }
             default:{
                 let credentials : IUserCredentials = {
-                    password : appManager.credential.password,
-                    username : appManager.credential.username
+                    password : appManager.credentials.password,
+                    username : appManager.credentials.username
                 };
                 
                 return credentials;

--- a/src/util/urlHelper.ts
+++ b/src/util/urlHelper.ts
@@ -53,6 +53,10 @@ export class UrlHelper{
         return filePath;
     } 
 
+    public static osAwareGlobStar(){
+        return path.sep + '**' + path.sep + '*.*';
+    }
+
     public static removeTrailingSlash(url: string): string {
         return url.replace(/(\/$)|(\\$)/, '');
     }

--- a/src/util/urlHelper.ts
+++ b/src/util/urlHelper.ts
@@ -38,6 +38,10 @@ export class UrlHelper{
         return Uri.parse(this.removeTrailingSlash(vscode.window.spgo.config.sharePointSiteUrl) + remoteFileUrl);
     }
 
+    public static formatUriAsFileName(uri : string){
+        return uri.replace(/[^a-zA-Z0-9]/g,'_');
+    }
+
     // properly append leading and trailing '/'s to a folder path.
     public static formatWebFolder(filePath : string) : string {
         if(!filePath.startsWith('/')){


### PR DESCRIPTION
## 1.3.1 - 2018-6-7
### Added
- Integrated [cpass](https://www.npmjs.com/package/cpass), allowing users to store credentials for each SharePoint site, removing the need to always reenter creds when launching SPGo. [Issue 47](https://github.com/readysitego/spgo/issues/47)
### Changed
- The `SPGo> Publish a major version of the current file` and `SPGo> Publish a major version of the current file` commands now works at the folder level. All other context menu items will gracefully fail with a message that they do not yet support operations at the folder-level.
### Fixed
- Found/fixed another Glob issue, related to globstar searches (e.g. `/directory/**/*.*`), hopefully resolving all cases of [Issue 46](https://github.com/readysitego/spgo/issues/46)
- Better URL concatenation prevents double-slashes when setting a SharePoint site URL ending in a slash, which resolves [Issue 50](https://github.com/readysitego/spgo/issues/50)
