### PR TITLE
fixed package naming, added NTLM v2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.3.2 - 2018-8-11
+### Added
+- Support for NTLM v2 authentication, via [node-sp-auth](https://www.npmjs.com/package/node-sp-auth/v/2.5.5) package upgrade
+### Fixed
+- Resolved an issue with file names in packaging. strictly cased file systems should be able to run SPGo without issue.
+
 ## 1.3.1 - 2018-6-7
 ### Added
 - Integrated [cpass](https://www.npmjs.com/package/cpass), allowing users to store credentials for each SharePoint site, removing the need to always reenter creds when launching SPGo. [Issue 47](https://github.com/readysitego/spgo/issues/47)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Features
     * Configuration data is stored within the project directory and can be stored in source control
 * Global Access
     * Support for Germany, China, and the US Government's private Office 365 deployments
+* Support for SharePoint Online and 2016 + 2013 on-premise
 
 
 Configuration and Getting Started
@@ -91,6 +92,7 @@ Credentials are stored in VSCode memory only. SPGo will only ask you for credent
 * Digest (Office365)
 * NTLM v1 (most on-premise installations)
 * NTLM v1 + wwwAuth
+* NTLM v2
 * ADFS
 
     _A note for ADFS Authentication:_ You will need to add the following JSON node to the root of your your SPGo.json file:

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,15 +34,7 @@
             "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
             "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
             "requires": {
-                "@types/node": "6.0.110"
-            }
-        },
-        "@types/fs-extra": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.2.tgz",
-            "integrity": "sha512-Q3FWsbdmkQd1ib11A4XNWQvRD//5KpPoGawA8aB2DR7pWKoW9XQv3+dGxD/Z1eVFze23Okdo27ZQytVFlweKvQ==",
-            "requires": {
-                "@types/node": "6.0.110"
+                "@types/node": "6.0.116"
             }
         },
         "@types/glob": {
@@ -52,7 +44,7 @@
             "requires": {
                 "@types/events": "1.2.0",
                 "@types/minimatch": "3.0.3",
-                "@types/node": "6.0.110"
+                "@types/node": "6.0.116"
             }
         },
         "@types/glob-stream": {
@@ -61,15 +53,15 @@
             "integrity": "sha512-RHv6ZQjcTncXo3thYZrsbAVwoy4vSKosSWhuhuQxLOTv74OJuFQxXkmUuZCr3q9uNBEVCvIzmZL/FeRNbHZGUg==",
             "requires": {
                 "@types/glob": "5.0.35",
-                "@types/node": "6.0.110"
+                "@types/node": "6.0.116"
             }
         },
         "@types/jsonwebtoken": {
-            "version": "7.2.7",
-            "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.7.tgz",
-            "integrity": "sha512-lq9X76APpxGJDUe1VptL1P5GrogqhPCH+SDy94+gaBJw7Hhj6hwrVC6zuxAx2GrgktkBuwydESZBvPfrdBoOEg==",
+            "version": "7.2.8",
+            "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz",
+            "integrity": "sha512-XENN3YzEB8D6TiUww0O8SRznzy1v+77lH7UmuN54xq/IHIsyWjWOzZuFFTtoiRuaE782uAoRwBe/wwow+vQXZw==",
             "requires": {
-                "@types/node": "6.0.110"
+                "@types/node": "6.0.116"
             }
         },
         "@types/lodash": {
@@ -89,16 +81,16 @@
             "dev": true
         },
         "@types/node": {
-            "version": "6.0.110",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.110.tgz",
-            "integrity": "sha512-LiaH3mF+OAqR+9Wo1OTJDbZDtCewAVjTbMhF1ZgUJ3fc8xqOJq6VqbpBh9dJVCVzByGmYIg2fREbuXNX0TKiJA=="
+            "version": "6.0.116",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.116.tgz",
+            "integrity": "sha512-vToa8YEeulfyYg1gSOeHjvvIRqrokng62VMSj2hoZrwZNcYrp2h3AWo6KeBVuymIklQUaY5zgVJvVsC4KiiLkQ=="
         },
         "@types/node-notifier": {
             "version": "0.0.28",
             "resolved": "https://registry.npmjs.org/@types/node-notifier/-/node-notifier-0.0.28.tgz",
             "integrity": "sha1-hro9OqjZGDUswxkdiN4yiyDck8E=",
             "requires": {
-                "@types/node": "6.0.110"
+                "@types/node": "6.0.116"
             }
         },
         "@types/request": {
@@ -108,7 +100,7 @@
             "requires": {
                 "@types/caseless": "0.12.1",
                 "@types/form-data": "2.2.1",
-                "@types/node": "6.0.110",
+                "@types/node": "6.0.116",
                 "@types/tough-cookie": "2.3.3"
             }
         },
@@ -131,7 +123,7 @@
             "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-1.2.30.tgz",
             "integrity": "sha1-kRXAxFxAxXVziQa+n7Tfb1ueUBM=",
             "requires": {
-                "@types/node": "6.0.110"
+                "@types/node": "6.0.116"
             }
         },
         "@types/vinyl-fs": {
@@ -140,7 +132,7 @@
             "integrity": "sha1-RmMBe8gCxlcOrk80Cf1cq/l8v94=",
             "requires": {
                 "@types/glob-stream": "6.1.0",
-                "@types/node": "6.0.110",
+                "@types/node": "6.0.116",
                 "@types/vinyl": "1.2.30"
             }
         },
@@ -167,14 +159,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
             "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
-        },
-        "ansi-gray": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-            "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-            "requires": {
-                "ansi-wrap": "0.1.0"
-            }
         },
         "ansi-red": {
             "version": "0.1.1",
@@ -293,11 +277,6 @@
                 "tweetnacl": "0.14.5"
             }
         },
-        "beeper": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
-        },
         "block-stream": {
             "version": "0.0.9",
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -361,9 +340,9 @@
             "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
         },
         "buffer-from": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-            "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+            "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
         },
         "caseless": {
             "version": "0.12.0",
@@ -441,11 +420,6 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
-        "color-support": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
-        },
         "colors": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
@@ -485,12 +459,12 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cpass": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/cpass/-/cpass-2.0.3.tgz",
-            "integrity": "sha512-bFswRHZf/O6RSitgeatNQ9pyzdeoTOl3+lLWGMIDF4BnHWMnuAxkl0qyN3sWLOpmUjjP6cckC7as8LUWWf/i4Q==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/cpass/-/cpass-2.0.4.tgz",
+            "integrity": "sha512-QN8hvKkgHUfg1FwMvRBOdcHMwk7ZvVuKCQVcX7gyZpVa6AyuwSY/4h9SHmQdBqh0vgMoiQF597PX1eZ9wKrbXg==",
             "requires": {
                 "os": "0.1.1",
-                "simple-encryptor": "1.3.0"
+                "simple-encryptor": "1.4.0"
             }
         },
         "cryptiles": {
@@ -524,24 +498,19 @@
                 "assert-plus": "1.0.0"
             }
         },
-        "dateformat": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-            "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
-        },
         "debug": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
             "dev": true,
             "requires": {
-                "ms": "0.7.1"
+                "ms": "2.0.0"
             },
             "dependencies": {
                 "ms": {
-                    "version": "0.7.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                    "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                     "dev": true
                 }
             }
@@ -560,46 +529,15 @@
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "diff": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-            "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+            "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
             "dev": true
         },
         "duplexer": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
-        },
-        "duplexer2": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-            "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-            "requires": {
-                "readable-stream": "1.1.14"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-                },
-                "readable-stream": {
-                    "version": "1.1.14",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                }
-            }
         },
         "duplexify": {
             "version": "3.6.0",
@@ -708,16 +646,6 @@
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
-        "fancy-log": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
-            "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
-            "requires": {
-                "ansi-gray": "0.1.1",
-                "color-support": "1.1.3",
-                "time-stamp": "1.1.0"
-            }
-        },
         "fast-deep-equal": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
@@ -729,9 +657,9 @@
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "fd-slicer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "requires": {
                 "pend": "1.2.0"
             }
@@ -956,23 +884,15 @@
                 "pinkie-promise": "2.0.1"
             }
         },
-        "glogg": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
-            "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
-            "requires": {
-                "sparkles": "1.0.1"
-            }
-        },
         "graceful-fs": {
             "version": "4.1.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
             "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "growl": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-            "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+            "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
             "dev": true
         },
         "growly": {
@@ -1064,7 +984,7 @@
                 "node.extend": "1.1.6",
                 "request": "2.86.0",
                 "through2": "2.0.3",
-                "vinyl": "2.1.0"
+                "vinyl": "2.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -1083,9 +1003,9 @@
                     "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
                 },
                 "vinyl": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-                    "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "requires": {
                         "clone": "2.1.1",
                         "clone-buffer": "1.0.0",
@@ -1121,97 +1041,15 @@
             }
         },
         "gulp-untar": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
-            "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
+            "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "requires": {
                 "event-stream": "3.3.4",
-                "gulp-util": "3.0.8",
                 "streamifier": "0.1.1",
                 "tar": "2.2.1",
-                "through2": "2.0.3"
-            }
-        },
-        "gulp-util": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-            "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-            "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
-                "replace-ext": "0.0.1",
                 "through2": "2.0.3",
-                "vinyl": "0.5.3"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                },
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                },
-                "object-assign": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                    "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "requires": {
-                        "ansi-regex": "2.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                },
-                "vinyl": {
-                    "version": "0.5.3",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-                    "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-                    "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                }
+                "vinyl": "1.2.0"
             }
         },
         "gulp-vinyl-zip": {
@@ -1222,9 +1060,9 @@
                 "event-stream": "3.3.4",
                 "queue": "4.4.2",
                 "through2": "2.0.3",
-                "vinyl": "2.1.0",
+                "vinyl": "2.2.0",
                 "vinyl-fs": "2.4.4",
-                "yauzl": "2.9.1",
+                "yauzl": "2.9.2",
                 "yazl": "2.4.3"
             },
             "dependencies": {
@@ -1252,9 +1090,9 @@
                     "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
                 },
                 "vinyl": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-                    "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "requires": {
                         "clone": "2.1.1",
                         "clone-buffer": "1.0.0",
@@ -1264,14 +1102,6 @@
                         "replace-ext": "1.0.0"
                     }
                 }
-            }
-        },
-        "gulplog": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-            "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-            "requires": {
-                "glogg": "1.0.1"
             }
         },
         "har-schema": {
@@ -1288,33 +1118,10 @@
                 "har-schema": "2.0.0"
             }
         },
-        "has-ansi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "requires": {
-                "ansi-regex": "2.1.1"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                }
-            }
-        },
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-        },
-        "has-gulplog": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-            "requires": {
-                "sparkles": "1.0.1"
-            }
         },
         "hawk": {
             "version": "6.0.2",
@@ -1338,11 +1145,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
             "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
-        },
-        "hoek": {
-            "version": "2.16.3",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
         },
         "http-signature": {
             "version": "1.2.0",
@@ -1519,11 +1321,6 @@
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
-        "isemail": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-            "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
-        },
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1541,41 +1338,6 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-        },
-        "jade": {
-            "version": "0.26.3",
-            "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-            "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-            "dev": true,
-            "requires": {
-                "commander": "0.6.1",
-                "mkdirp": "0.3.0"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-                    "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
-                    "dev": true
-                },
-                "mkdirp": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-                    "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-                    "dev": true
-                }
-            }
-        },
-        "joi": {
-            "version": "6.10.1",
-            "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-            "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-            "requires": {
-                "hoek": "2.16.3",
-                "isemail": "1.2.0",
-                "moment": "2.22.1",
-                "topo": "1.1.0"
-            }
         },
         "jsbn": {
             "version": "0.1.1",
@@ -1620,15 +1382,19 @@
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
         },
         "jsonwebtoken": {
-            "version": "7.4.3",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
-            "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
+            "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
             "requires": {
-                "joi": "6.10.1",
                 "jws": "3.1.5",
+                "lodash.includes": "4.3.0",
+                "lodash.isboolean": "3.0.3",
+                "lodash.isinteger": "4.0.4",
+                "lodash.isnumber": "3.0.3",
+                "lodash.isplainobject": "4.0.6",
+                "lodash.isstring": "4.0.1",
                 "lodash.once": "4.1.1",
-                "ms": "2.1.1",
-                "xtend": "4.0.1"
+                "ms": "2.1.1"
             }
         },
         "jsprim": {
@@ -1679,124 +1445,45 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
             "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
-        "lodash._basecopy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+        "lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
         },
-        "lodash._basetostring": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
-        },
-        "lodash._basevalues": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
-        },
-        "lodash._getnative": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-        },
-        "lodash._isiterateecall": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-        },
-        "lodash._reescape": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
-        },
-        "lodash._reevaluate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
-        },
-        "lodash._reinterpolate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-        },
-        "lodash._root": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
-        },
-        "lodash.escape": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-            "requires": {
-                "lodash._root": "3.0.1"
-            }
-        },
-        "lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-        },
-        "lodash.isarray": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+        "lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
         },
         "lodash.isequal": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
             "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
         },
-        "lodash.keys": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
-            }
+        "lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+        },
+        "lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
         },
         "lodash.once": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
-        },
-        "lodash.restparam": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-        },
-        "lodash.template": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-            "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
-            }
-        },
-        "lodash.templatesettings": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-            "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
-            }
-        },
-        "lru-cache": {
-            "version": "2.7.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-            "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-            "dev": true
         },
         "map-stream": {
             "version": "0.1.0",
@@ -1894,67 +1581,59 @@
             }
         },
         "mocha": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-            "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+            "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
             "dev": true,
             "requires": {
-                "commander": "2.3.0",
-                "debug": "2.2.0",
-                "diff": "1.4.0",
-                "escape-string-regexp": "1.0.2",
-                "glob": "3.2.11",
-                "growl": "1.9.2",
-                "jade": "0.26.3",
+                "browser-stdout": "1.3.0",
+                "commander": "2.11.0",
+                "debug": "3.1.0",
+                "diff": "3.3.1",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.3",
+                "he": "1.1.1",
                 "mkdirp": "0.5.1",
-                "supports-color": "1.2.0",
-                "to-iso-string": "0.0.2"
+                "supports-color": "4.4.0"
             },
             "dependencies": {
                 "commander": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-                    "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
-                    "dev": true
-                },
-                "escape-string-regexp": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-                    "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+                    "version": "2.11.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
                     "dev": true
                 },
                 "glob": {
-                    "version": "3.2.11",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-                    "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+                    "version": "7.1.2",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
                         "inherits": "2.0.1",
-                        "minimatch": "0.3.0"
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
-                "minimatch": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-                    "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
-                    }
+                "has-flag": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+                    "dev": true
                 },
                 "supports-color": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-                    "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
-                    "dev": true
+                    "version": "4.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+                    "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "2.0.0"
+                    }
                 }
             }
-        },
-        "moment": {
-            "version": "2.22.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-            "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
         },
         "ms": {
             "version": "2.1.1",
@@ -1970,14 +1649,6 @@
                 "array-union": "1.0.2",
                 "arrify": "1.0.1",
                 "minimatch": "3.0.4"
-            }
-        },
-        "multipipe": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-            "requires": {
-                "duplexer2": "0.0.2"
             }
         },
         "mute-stream": {
@@ -1996,25 +1667,34 @@
                 "which": "1.3.0"
             }
         },
+        "node-ntlm-client": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/node-ntlm-client/-/node-ntlm-client-0.1.2.tgz",
+            "integrity": "sha1-bAXiNLDZGUuwh5kpSYxvE5YshHI=",
+            "requires": {
+                "extend": "3.0.1",
+                "request": "2.86.0"
+            }
+        },
         "node-sp-auth": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/node-sp-auth/-/node-sp-auth-2.4.2.tgz",
-            "integrity": "sha512-8s9Oa3XO1lRG8BErH8QA2DPr5uvtTO14lRl+pMdttoOyC9rvW+VQ7V8/rKmaUmtkbKw1HOFkfChcT0KWsH5HiQ==",
+            "version": "2.5.5",
+            "resolved": "https://registry.npmjs.org/node-sp-auth/-/node-sp-auth-2.5.5.tgz",
+            "integrity": "sha512-2ywW+6baaOZzGM04Wk4+ovxvAs4DiBIvkw8WRlTZDB2y47//zhhrVK5cuNQe9/3bWLkAF4qeqJ0FyBIbP3nJhA==",
             "requires": {
                 "@types/bluebird": "3.5.20",
                 "@types/cookie": "0.1.29",
                 "@types/core-js": "0.9.46",
-                "@types/jsonwebtoken": "7.2.7",
+                "@types/jsonwebtoken": "7.2.8",
                 "@types/lodash": "4.14.108",
-                "@types/node": "6.0.110",
+                "@types/node": "6.0.116",
                 "@types/request": "2.47.0",
                 "@types/request-promise": "4.1.41",
                 "bluebird": "3.5.1",
                 "cookie": "0.3.1",
-                "cpass": "2.0.3",
-                "httpntlm": "1.7.5",
-                "jsonwebtoken": "7.4.3",
+                "cpass": "2.0.4",
+                "jsonwebtoken": "8.3.0",
                 "lodash": "4.17.10",
+                "node-ntlm-client": "0.1.2",
                 "node-sp-auth-config": "2.4.5",
                 "request": "2.86.0",
                 "request-promise": "4.2.2",
@@ -2028,10 +1708,10 @@
             "requires": {
                 "colors": "1.2.5",
                 "commander": "2.15.1",
-                "cpass": "2.0.3",
+                "cpass": "2.0.4",
                 "inquirer": "5.2.0",
                 "mkdirp": "0.5.1",
-                "node-sp-auth": "2.4.2"
+                "node-sp-auth": "2.5.5"
             }
         },
         "node.extend": {
@@ -2196,6 +1876,11 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
             "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "psl": {
+            "version": "1.1.29",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
+            "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
         },
         "punycode": {
             "version": "1.4.1",
@@ -2421,21 +2106,15 @@
             "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
             "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
         },
-        "sigmund": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-            "dev": true
-        },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "simple-encryptor": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/simple-encryptor/-/simple-encryptor-1.3.0.tgz",
-            "integrity": "sha512-/npEi/F34NhIwKoiKuQ98uZkxKzAXInQRvlA5SJ+7LoSyeoI6W9KfcAscmb7bjqqsTb/qzQ2C1bqCLqmAd13fA==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/simple-encryptor/-/simple-encryptor-1.4.0.tgz",
+            "integrity": "sha512-g7UhXQ6flzimqzoaDqjGl5hBh4/+tJ4dtAIHaWhO9gtt+GkLRb3F/Xjv//XORFstkNxA+CFVzZJCLhs24NmrSQ==",
             "requires": {
                 "scmp": "2.0.0"
             }
@@ -2465,7 +2144,7 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
             "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
             "requires": {
-                "buffer-from": "1.0.0",
+                "buffer-from": "1.1.0",
                 "source-map": "0.6.1"
             }
         },
@@ -2477,13 +2156,13 @@
                 "@types/bluebird": "3.5.20",
                 "@types/core-js": "0.9.46",
                 "@types/lodash": "4.14.108",
-                "@types/node": "6.0.110",
+                "@types/node": "6.0.116",
                 "@types/request": "0.0.31",
                 "@types/request-promise": "4.1.41",
                 "bluebird": "3.5.1",
                 "httpntlm": "1.7.5",
                 "lodash": "4.17.10",
-                "node-sp-auth": "2.4.2",
+                "node-sp-auth": "2.5.5",
                 "request": "2.86.0",
                 "request-promise": "4.2.2"
             },
@@ -2494,15 +2173,10 @@
                     "integrity": "sha1-6ed2YfdsWWpv0O26YiAFZnFxuus=",
                     "requires": {
                         "@types/form-data": "2.2.1",
-                        "@types/node": "6.0.110"
+                        "@types/node": "6.0.116"
                     }
                 }
             }
-        },
-        "sparkles": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
-            "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
         },
         "split": {
             "version": "0.3.3",
@@ -2513,15 +2187,161 @@
             }
         },
         "sppull": {
-            "version": "2.2.6",
-            "resolved": "https://registry.npmjs.org/sppull/-/sppull-2.2.6.tgz",
-            "integrity": "sha512-7ygXhaujhgmWpOPeLhRKfxIFZevwcQN6jXM/Q6nrsV1wblvlQsWfymxwKf4bjqmaxE67CdKBZdex8jvKoi8o+Q==",
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/sppull/-/sppull-2.2.7.tgz",
+            "integrity": "sha512-peAdczxF6Vsz6A3O+psKpUXJ6lx1bQKZlt/xudCFKsHViZBfBeEZ1ZkaW0OR2Ne24yHuIJ8NLdejjj7PAlyhcg==",
             "requires": {
-                "colors": "1.2.5",
+                "colors": "1.3.1",
                 "mkdirp": "0.5.1",
-                "node-sp-auth-config": "2.4.5",
-                "request": "2.86.0",
+                "node-sp-auth-config": "2.5.5",
+                "request": "2.88.0",
                 "sp-request": "2.1.3"
+            },
+            "dependencies": {
+                "aws4": {
+                    "version": "1.8.0",
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+                    "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+                },
+                "chardet": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.5.0.tgz",
+                    "integrity": "sha512-9ZTaoBaePSCFvNlNGrsyI8ZVACP2svUtq0DkM7t4K2ClAa96sqOIRjAzDTc8zXzFt1cZR46rRzLTiHFSJ+Qw0g=="
+                },
+                "colors": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.1.tgz",
+                    "integrity": "sha512-jg/vxRmv430jixZrC+La5kMbUWqIg32/JsYNZb94+JEmzceYbWKTsv1OuTp+7EaqiaWRR2tPcykibwCRgclIsw=="
+                },
+                "commander": {
+                    "version": "2.17.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+                    "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+                },
+                "extend": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+                    "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+                },
+                "external-editor": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.1.tgz",
+                    "integrity": "sha512-e1neqvSt5pSwQcFnYc6yfGuJD2Q4336cdbHs5VeUO0zTkqPbrHMyw2q1r47fpfLWbvIG8H8A6YO3sck7upTV6Q==",
+                    "requires": {
+                        "chardet": "0.5.0",
+                        "iconv-lite": "0.4.23",
+                        "tmp": "0.0.33"
+                    }
+                },
+                "har-validator": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+                    "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+                    "requires": {
+                        "ajv": "5.5.2",
+                        "har-schema": "2.0.0"
+                    }
+                },
+                "inquirer": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.1.0.tgz",
+                    "integrity": "sha512-f9K2MMx/G/AVmJSaZg2a+GVLRRmTdlGLbwxsibNd6yNTxXujqxPypjCnxnC0y4+Wb/rNY5KyKuq06AO5jrE+7w==",
+                    "requires": {
+                        "ansi-escapes": "3.1.0",
+                        "chalk": "2.4.1",
+                        "cli-cursor": "2.1.0",
+                        "cli-width": "2.2.0",
+                        "external-editor": "3.0.1",
+                        "figures": "2.0.0",
+                        "lodash": "4.17.10",
+                        "mute-stream": "0.0.7",
+                        "run-async": "2.3.0",
+                        "rxjs": "6.2.2",
+                        "string-width": "2.1.1",
+                        "strip-ansi": "4.0.0",
+                        "through": "2.3.8"
+                    }
+                },
+                "mime-db": {
+                    "version": "1.35.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+                    "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+                },
+                "mime-types": {
+                    "version": "2.1.19",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+                    "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+                    "requires": {
+                        "mime-db": "1.35.0"
+                    }
+                },
+                "node-sp-auth-config": {
+                    "version": "2.5.5",
+                    "resolved": "https://registry.npmjs.org/node-sp-auth-config/-/node-sp-auth-config-2.5.5.tgz",
+                    "integrity": "sha512-rDqsSfuVcSW5xBCJ/O+EAvN42Xkt0hcqAFymoRQ4FvOX7rmmCF4O7V+otsocvVx8TYKdWQPXlvRZ4T91IZKusg==",
+                    "requires": {
+                        "colors": "1.3.1",
+                        "commander": "2.17.1",
+                        "cpass": "2.0.4",
+                        "inquirer": "6.1.0",
+                        "mkdirp": "0.5.1",
+                        "node-sp-auth": "2.5.5"
+                    }
+                },
+                "oauth-sign": {
+                    "version": "0.9.0",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+                    "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+                },
+                "request": {
+                    "version": "2.88.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+                    "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+                    "requires": {
+                        "aws-sign2": "0.7.0",
+                        "aws4": "1.8.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.6",
+                        "extend": "3.0.2",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.3.2",
+                        "har-validator": "5.1.0",
+                        "http-signature": "1.2.0",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.19",
+                        "oauth-sign": "0.9.0",
+                        "performance-now": "2.1.0",
+                        "qs": "6.5.2",
+                        "safe-buffer": "5.1.2",
+                        "tough-cookie": "2.4.3",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.3.2"
+                    }
+                },
+                "rxjs": {
+                    "version": "6.2.2",
+                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
+                    "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
+                    "requires": {
+                        "tslib": "1.9.3"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+                    "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+                    "requires": {
+                        "psl": "1.1.29",
+                        "punycode": "1.4.1"
+                    }
+                },
+                "uuid": {
+                    "version": "3.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+                }
             }
         },
         "spsave": {
@@ -2532,7 +2352,7 @@
                 "@types/bluebird": "3.5.20",
                 "@types/core-js": "0.9.46",
                 "@types/lodash": "4.14.108",
-                "@types/node": "6.0.110",
+                "@types/node": "6.0.116",
                 "@types/node-notifier": "0.0.28",
                 "@types/vinyl": "1.2.30",
                 "@types/vinyl-fs": "0.0.28",
@@ -2684,11 +2504,6 @@
                 "xtend": "4.0.1"
             }
         },
-        "time-stamp": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
-        },
         "tmp": {
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -2715,20 +2530,6 @@
                 }
             }
         },
-        "to-iso-string": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-            "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
-            "dev": true
-        },
-        "topo": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-            "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-            "requires": {
-                "hoek": "2.16.3"
-            }
-        },
         "tough-cookie": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
@@ -2736,6 +2537,11 @@
             "requires": {
                 "punycode": "1.4.1"
             }
+        },
+        "tslib": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
         },
         "tunnel-agent": {
             "version": "0.6.0",
@@ -2777,9 +2583,9 @@
             "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
         },
         "url-parse": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
-            "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
+            "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
             "requires": {
                 "querystringify": "2.0.0",
                 "requires-port": "1.0.0"
@@ -2878,9 +2684,9 @@
             }
         },
         "vscode": {
-            "version": "1.1.17",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.17.tgz",
-            "integrity": "sha512-yNMyrgEua2qyW7+trNNYhA6PeldRrBcwtLtlazkdtzcmkHMKECM/08bPF8HF2ZFuwHgD+8FQsdqd/DvJYQYjJg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.18.tgz",
+            "integrity": "sha512-SyDw4qFwZ+WthZX7RWp71PNiWLF7VhpM65j2oryY/6jtSORd8qH6J8vclwWZJ6Jvu0EH7JamO2RWNfBfsMR9Zw==",
             "requires": {
                 "glob": "7.1.2",
                 "gulp-chmod": "2.0.0",
@@ -2888,13 +2694,13 @@
                 "gulp-gunzip": "1.0.0",
                 "gulp-remote-src-vscode": "0.5.0",
                 "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.6",
+                "gulp-untar": "0.0.7",
                 "gulp-vinyl-zip": "2.1.0",
                 "mocha": "4.1.0",
                 "request": "2.86.0",
                 "semver": "5.5.0",
                 "source-map-support": "0.5.6",
-                "url-parse": "1.4.0",
+                "url-parse": "1.4.1",
                 "vinyl-source-stream": "1.1.2"
             },
             "dependencies": {
@@ -2972,9 +2778,9 @@
             }
         },
         "vscode-uri": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.3.tgz",
-            "integrity": "sha1-Yxvb9xbcyrDmUpGo3CXCMjIIWlI="
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.5.tgz",
+            "integrity": "sha1-O4majvccN/MFTXm9vdoxx7828g0="
         },
         "which": {
             "version": "1.3.0",
@@ -3003,12 +2809,12 @@
             "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         },
         "yauzl": {
-            "version": "2.9.1",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
-            "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.2.tgz",
+            "integrity": "sha1-T7G8euH8L1cDe1SvasyP4QMcW3c=",
             "requires": {
                 "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.0.1"
+                "fd-slicer": "1.1.0"
             }
         },
         "yazl": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "o365",
         "ide"
     ],
-    "version": "1.3.1",
+    "version": "1.3.2",
     "publisher": "SiteGo",
     "icon": "assets/SiteGoLogo.png",
     "galleryBanner": {
@@ -179,20 +179,20 @@
     },
     "devDependencies": {
         "@types/mocha": "^2.2.32",
-        "@types/node": "^6.0.109",
+        "@types/node": "^6.0.116",
         "mocha": "^4.0.1",
         "typescript": "2.5.0"
     },
     "dependencies": {
-        "cpass": "^2.0.3",
+        "cpass": "^2.0.4",
         "fs-extra": "^4.0.3",
-        "node-sp-auth": "^2.4.2",
+        "node-sp-auth": "^2.5.5",
         "parse-glob": "^3.0.4",
         "path": "^0.12.7",
         "sp-request": "^2.1.3",
-        "sppull": "^2.2.6",
+        "sppull": "^2.2.7",
         "spsave": "^3.1.5",
-        "vscode": "^1.1.17",
-        "vscode-uri": "^1.0.3"
+        "vscode": "^1.1.18",
+        "vscode-uri": "^1.0.5"
     }
 }

--- a/src/command/discardCheckOut.ts
+++ b/src/command/discardCheckOut.ts
@@ -11,10 +11,12 @@ import {AuthenticationService} from './../service/authenticationService';
 
 export default function discardCheckOut(fileUri: vscode.Uri) : Thenable<any> {
 
-    //is this a directory?
+    // is this a directory?
+    // if so, tell the user we are too lazy to implement a recursive version of discard checkout.
     if(fs.lstatSync(fileUri.fsPath).isDirectory()){
         Logger.showWarning('The discard file check-out command only works for single files at this time.')
     }
+    // undo the checkout.
     else{
         if( fileUri.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
             let fileName : string = FileHelper.getFileName(fileUri.fsPath);

--- a/src/service/authenticationService.ts
+++ b/src/service/authenticationService.ts
@@ -7,6 +7,14 @@ import { CredentialDao } from '../dao/credentialDao';
 import { RequestHelper } from './../util/requestHelper'
 
 export class AuthenticationService{
+	
+	// Performs Three checks:
+	// 1. are the current in-memory credentials valid?
+	// 2. If not:
+	// 2a. Get new credentials (Username + Password)
+	// 2b. Validate User credentials
+	// 2c. Fail if new credentials are valid
+	// 3. Continue to execute the promise object provided.
 	static verifyCredentials(appManager : IAppManager, payload? : any): Promise<any> {
 		appManager = appManager || vscode.window.spgo;
 	
@@ -27,6 +35,7 @@ export class AuthenticationService{
 			appManager.credentials = {};
 		} 
 	
+		// take user's SharePoint username input
 		function getUserName(appManager) {
 			return new Promise(function (resolve, reject) {
 				let options: vscode.InputBoxOptions = {
@@ -46,6 +55,7 @@ export class AuthenticationService{
 			});
 		}
 	
+		// take user's password input
 		function getPassword(appManager) {
 			return new Promise(function (resolve, reject) {
 				let options: vscode.InputBoxOptions = {
@@ -87,6 +97,7 @@ export class AuthenticationService{
 			});
 		}
 
+		// Authtntication was successful, process the command provided by the caller.
 		function processNextCommand(appManager) {			
 			return new Promise(function (resolve, reject) {
 				if(appManager && appManager.credentials){

--- a/src/util/urlHelper.ts
+++ b/src/util/urlHelper.ts
@@ -6,6 +6,7 @@ import Uri from 'vscode-uri'
 
 export class UrlHelper{
     
+    //Make sure there is a leading slash.
     public static ensureLeadingSlash(filePath : string) : string{
         if(!filePath.startsWith(path.sep)){
             filePath = path.sep + filePath;
@@ -13,6 +14,7 @@ export class UrlHelper{
         return filePath;
     }
 
+    //Make sure there is a leading web slash (This is sort of a multi-platform hack).
     public static ensureLeadingWebSlash(filePath : string) : string{
         if(!filePath.startsWith('/')){
             filePath = '/' + filePath;
@@ -20,6 +22,7 @@ export class UrlHelper{
         return filePath;
     }
 
+    //get the file path relative to the current SharePoint site.
     public static getSiteRelativeFileUri(fileName : string) : string {
         return fileName.split(vscode.window.spgo.config.workspaceRoot + path.sep)[1].toString();
     }
@@ -53,18 +56,23 @@ export class UrlHelper{
         return filePath;
     } 
 
+    // make our glob processor os aware.
+    // this is also for cross-platform compatibility, but much less hacky.
     public static osAwareGlobStar(){
         return path.sep + '**' + path.sep + '*.*';
     }
 
+    //Make sure there is no leading slash.
     public static removeTrailingSlash(url: string): string {
         return url.replace(/(\/$)|(\\$)/, '');
     }
     
+    //Make sure there is no leading slash.
     public static removeLeadingSlash(url: string): string {
         return url.replace(/(^\/)|(^\\)/, '');
     }
 
+    //Make sure there are no slashes either place.
     public static trimSlashes(url: string): string {
         return url.replace(/(^\/)|(^\\)|(\/$)|(\\$)/g, '');
     }


### PR DESCRIPTION
### Added
- Support for NTLM v2 authentication, via [node-sp-auth](https://www.npmjs.com/package/node-sp-auth/v/2.5.5) package upgrade
### Fixed
- Resolved an issue with file names in packaging. strictly cased file systems should be able to run SPGo without issue.