### PR TITLE
1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.3.3 - 2018-10-30
+### Added
+- Running any SPGo-based command will now activate SPGo, or prompt you to configure a local workspace if no `spgo.json` config file is present. Great UX enhancement idea via email request.
+### Fixed
+- [This Issue](https://github.com/readysitego/spgo/issues/64) where SPGo *did not* consistently apply the correct auth headers for NTLM + www Auth, which *did* consistently annoying users.
+- [This Other Issue](https://github.com/readysitego/spgo/issues/63) where SPGo was unable to download files outside of folders. Really I didn't do much outside of type "npm update", as the heavy lifting was done by [@koltyakov](https://github.com/koltyakov). THANKS!
+- [This Other, Other, Issue](https://github.com/readysitego/spgo/issues/60) where json files without json extensions did not properly download. Again, thanks to [@koltyakov](https://github.com/koltyakov) for providing a fix via his great [sppull](https://github.com/koltyakov/sppull) library!
+
 ## 1.3.2 - 2018-8-11
 ### Added
 - Support for NTLM v2 authentication, via [node-sp-auth](https://www.npmjs.com/package/node-sp-auth/v/2.5.5) package upgrade

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Credentials are stored in VSCode memory only. SPGo will only ask you for credent
     _A note for ADFS Authentication:_ You will need to add the following JSON node to the root of your your SPGo.json file:
     ```json
     "authenticationDetails": {
-        "relayingParty": "[relaying party]",
+        "relyingParty": "[relying party]",
         "adfsUrl": "[ADFS Url]"
     }
     ```

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -57,3 +57,7 @@ toc:
         url: /spgo/advanced/spgo-and-sdlc
       - page: GitHub Integration
         url: /spgo/advanced/github-integration
+  - title: Development
+    subfolderitems:
+      - page: Building SPGo locally
+        url: /spgo/development/build-locally

--- a/docs/advanced/upload-minified.md
+++ b/docs/advanced/upload-minified.md
@@ -1,0 +1,6 @@
+---
+layout: page
+title: Handling Processed Files
+---
+
+## Comming Soon

--- a/docs/development/build-locally.md
+++ b/docs/development/build-locally.md
@@ -1,0 +1,32 @@
+---
+layout: page
+title: Github Integration
+---
+
+Building and running SPGo locally requires that you configure your host for VSCode plugin development. You will need the following tools installed:
+
+* [Node.js](https://nodejs.org/en/download/)
+* [NPM](https://www.npmjs.com/get-npm)
+
+## Building and installing SPGo locally
+1. globally install the vsce tools: `sudo npm install -g vsce`
+2. get latest from master branch: 
+    * `git clone https://github.com/readysitego/spgo`
+3. get packages: `npm install`
+4. Build and install package manually:
+    * `vsce package`
+    * `code --install-extension <package>.vsix` 
+    where `<package>` is the name of the package generated in the step above.
+
+
+## Building and installing SPGo locally from a specific branch
+1. globally install the vsce tools: `sudo npm install -g vsce`
+2. get latest from master branch: 
+    * `git clone https://github.com/readysitego/spgo`
+    * `git checkout <branch>`
+    * `git pull`
+3. get packages: `npm install`
+4. Build and install package manually:
+    * `vsce package`
+    * `code --install-extension <package>.vsix` 
+    where `<package>` is the name of the package generated in the step above.

--- a/docs/general/config-options.md
+++ b/docs/general/config-options.md
@@ -17,11 +17,11 @@ Options:
 Read more: [Authentication Types](https://github.com/readysitego/spgo/wiki#authentication)
 
 ## authenticationDetails
-When using ADFS Authentication, you will need to specify additional details in this node describing the ADFS url and relaying party.
+When using ADFS Authentication, you will need to specify additional details in this node describing the ADFS url and relying party.
 
 ```json
     "authenticationDetails": {
-        "relayingParty": "[relaying party]",
+        "relyingParty": "[relying party]",
         "adfsUrl": "[ADFS Url]"
     }
 ```
@@ -65,7 +65,7 @@ _note: SPGo can store unique credentials for each site collection you work with.
     "publishWorkspaceGlobPattern" : "/**/*.min.*",
     "authenticationType": "ADFS",
     "authenticationDetails": {
-        "relayingParty": "[relaying party]",
+        "relyingParty": "[relying party]",
         "adfsUrl": "[ADFS Url]"
     },
     "checkInMessage" : "Custom Publishing Message",

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ SPGo was created to make it easier to build SharePoint web and branding solution
 * [Digest (Office365)](/spgo/authentication/adfs-authentication)
 * [Forms](/spgo/authentication/forms-authentication)
 * [NTLM v1 (most on-premise installations)](/spgo/authentication/ntlm-authentication)
-* [NTLM v1 + wwwAuth](/spgo/authentication/ntlm-www-Authentication)
+* [NTLM v1 + wwwAuth](/spgo/authentication/ntlm-with-www-Authentication)
 * [NTLM v2 ](/spgo/authentication/ntlm-v2-authentication)
 * [ADFS](/spgo/authentication/adfs-authentication)
 * [Two-Factor](./spgo/authentication/two-factor-authentication)

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,9 @@ SPGo was created to make it easier to build SharePoint web and branding solution
 * [SDLC Best Practices](/spgo/advanced/spgo-and-sdlc)
 * [GitHub integration](/spgo/advanced/github-integration)
 
+### Development
+* [Building SPGo locally](/spgo/development/build-locally)
+
 ## Getting in touch
 Write an email, create an issue on git, @ us on twitter or request support via Stack Overflow. Any way you choose, we embrace feedback and want to hear from you. Here's how to get a hold of us:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "spgo",
-    "version": "1.3.1",
+    "version": "1.3.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -34,7 +34,7 @@
             "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
             "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
             "requires": {
-                "@types/node": "6.0.116"
+                "@types/node": "6.14.0"
             }
         },
         "@types/glob": {
@@ -44,7 +44,7 @@
             "requires": {
                 "@types/events": "1.2.0",
                 "@types/minimatch": "3.0.3",
-                "@types/node": "6.0.116"
+                "@types/node": "6.14.0"
             }
         },
         "@types/glob-stream": {
@@ -53,7 +53,7 @@
             "integrity": "sha512-RHv6ZQjcTncXo3thYZrsbAVwoy4vSKosSWhuhuQxLOTv74OJuFQxXkmUuZCr3q9uNBEVCvIzmZL/FeRNbHZGUg==",
             "requires": {
                 "@types/glob": "5.0.35",
-                "@types/node": "6.0.116"
+                "@types/node": "6.14.0"
             }
         },
         "@types/jsonwebtoken": {
@@ -61,7 +61,7 @@
             "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz",
             "integrity": "sha512-XENN3YzEB8D6TiUww0O8SRznzy1v+77lH7UmuN54xq/IHIsyWjWOzZuFFTtoiRuaE782uAoRwBe/wwow+vQXZw==",
             "requires": {
-                "@types/node": "6.0.116"
+                "@types/node": "6.14.0"
             }
         },
         "@types/lodash": {
@@ -81,16 +81,16 @@
             "dev": true
         },
         "@types/node": {
-            "version": "6.0.116",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.116.tgz",
-            "integrity": "sha512-vToa8YEeulfyYg1gSOeHjvvIRqrokng62VMSj2hoZrwZNcYrp2h3AWo6KeBVuymIklQUaY5zgVJvVsC4KiiLkQ=="
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.0.tgz",
+            "integrity": "sha512-6tQyh4Q4B5pECcXBOQDZ5KjyBIxRZGzrweGPM47sAYTdVG4+7R+2EGMTmp0h6ZwgqHrFRCeg2gdhsG9xXEl2Sg=="
         },
         "@types/node-notifier": {
             "version": "0.0.28",
             "resolved": "https://registry.npmjs.org/@types/node-notifier/-/node-notifier-0.0.28.tgz",
             "integrity": "sha1-hro9OqjZGDUswxkdiN4yiyDck8E=",
             "requires": {
-                "@types/node": "6.0.116"
+                "@types/node": "6.14.0"
             }
         },
         "@types/request": {
@@ -100,7 +100,7 @@
             "requires": {
                 "@types/caseless": "0.12.1",
                 "@types/form-data": "2.2.1",
-                "@types/node": "6.0.116",
+                "@types/node": "6.14.0",
                 "@types/tough-cookie": "2.3.3"
             }
         },
@@ -123,7 +123,7 @@
             "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-1.2.30.tgz",
             "integrity": "sha1-kRXAxFxAxXVziQa+n7Tfb1ueUBM=",
             "requires": {
-                "@types/node": "6.0.116"
+                "@types/node": "6.14.0"
             }
         },
         "@types/vinyl-fs": {
@@ -132,7 +132,7 @@
             "integrity": "sha1-RmMBe8gCxlcOrk80Cf1cq/l8v94=",
             "requires": {
                 "@types/glob-stream": "6.1.0",
-                "@types/node": "6.0.116",
+                "@types/node": "6.14.0",
                 "@types/vinyl": "1.2.30"
             }
         },
@@ -178,7 +178,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "requires": {
-                "color-convert": "1.9.1"
+                "color-convert": "1.9.3"
             }
         },
         "ansi-wrap": {
@@ -321,7 +321,7 @@
             "requires": {
                 "expand-range": "1.8.2",
                 "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "repeat-element": "1.1.3"
             }
         },
         "browser-stdout": {
@@ -340,9 +340,9 @@
             "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
         },
         "buffer-from": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-            "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
         },
         "caseless": {
             "version": "0.12.0",
@@ -356,13 +356,13 @@
             "requires": {
                 "ansi-styles": "3.2.1",
                 "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "supports-color": "5.5.0"
             }
         },
         "chardet": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
         },
         "cli-cursor": {
             "version": "2.1.0",
@@ -408,9 +408,9 @@
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "color-convert": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -434,9 +434,9 @@
             }
         },
         "commander": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+            "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
         },
         "concat-map": {
             "version": "0.0.1",
@@ -444,9 +444,12 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "convert-source-map": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+            "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+            "requires": {
+                "safe-buffer": "5.1.2"
+            }
         },
         "cookie": {
             "version": "0.3.1",
@@ -459,11 +462,10 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cpass": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/cpass/-/cpass-2.0.4.tgz",
-            "integrity": "sha512-QN8hvKkgHUfg1FwMvRBOdcHMwk7ZvVuKCQVcX7gyZpVa6AyuwSY/4h9SHmQdBqh0vgMoiQF597PX1eZ9wKrbXg==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/cpass/-/cpass-2.0.5.tgz",
+            "integrity": "sha512-LBe6HD6b58YTF6ovlngw0+bn1UKl1XGfQ8eDqnzDXbuhK53h0XT3tMYY/8LtB2w2uiTFN6HjdKgJmyX5mQtKSQ==",
             "requires": {
-                "os": "0.1.1",
                 "simple-encryptor": "1.4.0"
             }
         },
@@ -502,7 +504,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
             "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-            "dev": true,
             "requires": {
                 "ms": "2.0.0"
             },
@@ -510,8 +511,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -531,8 +531,7 @@
         "diff": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-            "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
-            "dev": true
+            "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
         },
         "duplexer": {
             "version": "0.1.1",
@@ -540,9 +539,9 @@
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
         },
         "duplexify": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
-            "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
+            "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
             "requires": {
                 "end-of-stream": "1.4.1",
                 "inherits": "2.0.1",
@@ -581,16 +580,17 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "event-stream": {
-            "version": "3.3.4",
-            "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-            "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
+            "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
             "requires": {
                 "duplexer": "0.1.1",
+                "flatmap-stream": "0.1.1",
                 "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "map-stream": "0.0.7",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
+                "split": "1.0.1",
+                "stream-combiner": "0.2.2",
                 "through": "2.3.8"
             }
         },
@@ -624,12 +624,12 @@
             }
         },
         "external-editor": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-            "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+            "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
             "requires": {
-                "chardet": "0.4.2",
-                "iconv-lite": "0.4.23",
+                "chardet": "0.7.0",
+                "iconv-lite": "0.4.24",
                 "tmp": "0.0.33"
             }
         },
@@ -684,8 +684,8 @@
             "requires": {
                 "is-number": "2.1.0",
                 "isobject": "2.1.0",
-                "randomatic": "3.0.0",
-                "repeat-element": "1.1.2",
+                "randomatic": "3.1.1",
+                "repeat-element": "1.1.3",
                 "repeat-string": "1.6.1"
             }
         },
@@ -693,6 +693,11 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
             "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
+        },
+        "flatmap-stream": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
+            "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw=="
         },
         "for-in": {
             "version": "1.0.2",
@@ -892,8 +897,7 @@
         "growl": {
             "version": "1.10.3",
             "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-            "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
-            "dev": true
+            "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
         },
         "growly": {
             "version": "1.3.0",
@@ -980,7 +984,7 @@
             "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.0.tgz",
             "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
             "requires": {
-                "event-stream": "3.3.4",
+                "event-stream": "3.3.6",
                 "node.extend": "1.1.6",
                 "request": "2.86.0",
                 "through2": "2.0.3",
@@ -988,9 +992,9 @@
             },
             "dependencies": {
                 "clone": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
                 },
                 "clone-stats": {
                     "version": "1.0.0",
@@ -1007,7 +1011,7 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "requires": {
-                        "clone": "2.1.1",
+                        "clone": "2.1.2",
                         "clone-buffer": "1.0.0",
                         "clone-stats": "1.0.0",
                         "cloneable-readable": "1.1.2",
@@ -1022,7 +1026,7 @@
             "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "requires": {
-                "convert-source-map": "1.5.1",
+                "convert-source-map": "1.6.0",
                 "graceful-fs": "4.1.11",
                 "strip-bom": "2.0.0",
                 "through2": "2.0.3",
@@ -1034,7 +1038,7 @@
             "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "requires": {
-                "event-stream": "3.3.4",
+                "event-stream": "3.3.6",
                 "mkdirp": "0.5.1",
                 "queue": "3.1.0",
                 "vinyl-fs": "2.4.4"
@@ -1045,7 +1049,7 @@
             "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
             "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "requires": {
-                "event-stream": "3.3.4",
+                "event-stream": "3.3.6",
                 "streamifier": "0.1.1",
                 "tar": "2.2.1",
                 "through2": "2.0.3",
@@ -1057,19 +1061,19 @@
             "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "requires": {
-                "event-stream": "3.3.4",
-                "queue": "4.4.2",
+                "event-stream": "3.3.6",
+                "queue": "4.5.0",
                 "through2": "2.0.3",
                 "vinyl": "2.2.0",
                 "vinyl-fs": "2.4.4",
-                "yauzl": "2.9.2",
+                "yauzl": "2.10.0",
                 "yazl": "2.4.3"
             },
             "dependencies": {
                 "clone": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
                 },
                 "clone-stats": {
                     "version": "1.0.0",
@@ -1077,9 +1081,9 @@
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
                 },
                 "queue": {
-                    "version": "4.4.2",
-                    "resolved": "https://registry.npmjs.org/queue/-/queue-4.4.2.tgz",
-                    "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.0.tgz",
+                    "integrity": "sha512-DwxpAnqJuoQa+wyDgQuwkSshkhlqIlWEvwvdAY27fDPunZ2cVJzXU4JyjY+5l7zs7oGLaYAQm4MbLOVFAHFBzA==",
                     "requires": {
                         "inherits": "2.0.1"
                     }
@@ -1094,7 +1098,7 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "requires": {
-                        "clone": "2.1.1",
+                        "clone": "2.1.2",
                         "clone-buffer": "1.0.0",
                         "clone-stats": "1.0.0",
                         "cloneable-readable": "1.1.2",
@@ -1171,9 +1175,9 @@
             "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8="
         },
         "iconv-lite": {
-            "version": "0.4.23",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-            "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "requires": {
                 "safer-buffer": "2.1.2"
             }
@@ -1193,20 +1197,20 @@
             "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
         },
         "inquirer": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-            "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+            "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
             "requires": {
                 "ansi-escapes": "3.1.0",
                 "chalk": "2.4.1",
                 "cli-cursor": "2.1.0",
                 "cli-width": "2.2.0",
-                "external-editor": "2.2.0",
+                "external-editor": "3.0.3",
                 "figures": "2.0.0",
                 "lodash": "4.17.10",
                 "mute-stream": "0.0.7",
                 "run-async": "2.3.0",
-                "rxjs": "5.5.10",
+                "rxjs": "6.3.3",
                 "string-width": "2.1.1",
                 "strip-ansi": "4.0.0",
                 "through": "2.3.8"
@@ -1486,9 +1490,9 @@
             "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
         },
         "map-stream": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+            "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
         },
         "math-random": {
             "version": "1.0.1",
@@ -1584,7 +1588,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
             "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
-            "dev": true,
             "requires": {
                 "browser-stdout": "1.3.0",
                 "commander": "2.11.0",
@@ -1601,14 +1604,12 @@
                 "commander": {
                     "version": "2.11.0",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-                    "dev": true
+                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
                 },
                 "glob": {
                     "version": "7.1.2",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-                    "dev": true,
                     "requires": {
                         "fs.realpath": "1.0.0",
                         "inflight": "1.0.6",
@@ -1621,14 +1622,12 @@
                 "has-flag": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-                    "dev": true
+                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                 },
                 "supports-color": {
                     "version": "4.4.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-                    "dev": true,
                     "requires": {
                         "has-flag": "2.0.0"
                     }
@@ -1677,41 +1676,48 @@
             }
         },
         "node-sp-auth": {
-            "version": "2.5.5",
-            "resolved": "https://registry.npmjs.org/node-sp-auth/-/node-sp-auth-2.5.5.tgz",
-            "integrity": "sha512-2ywW+6baaOZzGM04Wk4+ovxvAs4DiBIvkw8WRlTZDB2y47//zhhrVK5cuNQe9/3bWLkAF4qeqJ0FyBIbP3nJhA==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/node-sp-auth/-/node-sp-auth-2.5.6.tgz",
+            "integrity": "sha512-kzwShVdmfGzT88seL3YfBXzESv3rTARVOZQ3IUjA1aCTtghrujdYrKAtrOTphP2EYhcHeXbi3OLBXMQxet+svw==",
             "requires": {
                 "@types/bluebird": "3.5.20",
                 "@types/cookie": "0.1.29",
                 "@types/core-js": "0.9.46",
                 "@types/jsonwebtoken": "7.2.8",
                 "@types/lodash": "4.14.108",
-                "@types/node": "6.0.116",
+                "@types/node": "6.14.0",
                 "@types/request": "2.47.0",
                 "@types/request-promise": "4.1.41",
                 "bluebird": "3.5.1",
                 "cookie": "0.3.1",
-                "cpass": "2.0.4",
+                "cpass": "2.0.5",
                 "jsonwebtoken": "8.3.0",
                 "lodash": "4.17.10",
                 "node-ntlm-client": "0.1.2",
-                "node-sp-auth-config": "2.4.5",
+                "node-sp-auth-config": "2.5.6",
                 "request": "2.86.0",
                 "request-promise": "4.2.2",
                 "xmldoc": "0.5.1"
             }
         },
         "node-sp-auth-config": {
-            "version": "2.4.5",
-            "resolved": "https://registry.npmjs.org/node-sp-auth-config/-/node-sp-auth-config-2.4.5.tgz",
-            "integrity": "sha512-5Cx1cN1zzs1aRzbMtmkQqehNKCkSmeoa4l8cxVesiE0IX4YW9BSfyKzHOABAcnHWfFdUs7kZxMBBVT4Fuxj84w==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/node-sp-auth-config/-/node-sp-auth-config-2.5.6.tgz",
+            "integrity": "sha512-vgXXr8LImQ7Sh79jM4zVNll4AKKoB4nXLuAAwIja/p8k4naS8BPqmaAvelg5x+O70fvOV7BJp6GVXZRNuTB5aw==",
             "requires": {
-                "colors": "1.2.5",
-                "commander": "2.15.1",
-                "cpass": "2.0.4",
-                "inquirer": "5.2.0",
+                "colors": "1.3.2",
+                "commander": "2.19.0",
+                "cpass": "2.0.5",
+                "inquirer": "6.2.0",
                 "mkdirp": "0.5.1",
-                "node-sp-auth": "2.5.5"
+                "node-sp-auth": "2.5.6"
+            },
+            "dependencies": {
+                "colors": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
+                    "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
+                }
             }
         },
         "node.extend": {
@@ -1773,11 +1779,6 @@
                 "is-stream": "1.1.0",
                 "readable-stream": "2.3.6"
             }
-        },
-        "os": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-            "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
         },
         "os-tmpdir": {
             "version": "1.0.2",
@@ -1893,9 +1894,9 @@
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "querystringify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
-            "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+            "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
         },
         "queue": {
             "version": "3.1.0",
@@ -1906,9 +1907,9 @@
             }
         },
         "randomatic": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-            "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+            "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
             "requires": {
                 "is-number": "4.0.0",
                 "kind-of": "6.0.2",
@@ -1962,9 +1963,9 @@
             "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
         },
         "repeat-element": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
         },
         "repeat-string": {
             "version": "1.6.1",
@@ -2042,13 +2043,13 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "requires": {
-                "glob": "7.1.2"
+                "glob": "7.1.3"
             },
             "dependencies": {
                 "glob": {
-                    "version": "7.1.2",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "version": "7.1.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                     "requires": {
                         "fs.realpath": "1.0.0",
                         "inflight": "1.0.6",
@@ -2069,11 +2070,11 @@
             }
         },
         "rxjs": {
-            "version": "5.5.10",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
-            "integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
+            "version": "6.3.3",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+            "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
             "requires": {
-                "symbol-observable": "1.0.1"
+                "tslib": "1.9.3"
             }
         },
         "safe-buffer": {
@@ -2140,11 +2141,11 @@
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "source-map-support": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-            "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+            "version": "0.5.9",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+            "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
             "requires": {
-                "buffer-from": "1.1.0",
+                "buffer-from": "1.1.1",
                 "source-map": "0.6.1"
             }
         },
@@ -2156,13 +2157,13 @@
                 "@types/bluebird": "3.5.20",
                 "@types/core-js": "0.9.46",
                 "@types/lodash": "4.14.108",
-                "@types/node": "6.0.116",
+                "@types/node": "6.14.0",
                 "@types/request": "0.0.31",
                 "@types/request-promise": "4.1.41",
                 "bluebird": "3.5.1",
                 "httpntlm": "1.7.5",
                 "lodash": "4.17.10",
-                "node-sp-auth": "2.5.5",
+                "node-sp-auth": "2.5.6",
                 "request": "2.86.0",
                 "request-promise": "4.2.2"
             },
@@ -2173,27 +2174,27 @@
                     "integrity": "sha1-6ed2YfdsWWpv0O26YiAFZnFxuus=",
                     "requires": {
                         "@types/form-data": "2.2.1",
-                        "@types/node": "6.0.116"
+                        "@types/node": "6.14.0"
                     }
                 }
             }
         },
         "split": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
             "requires": {
                 "through": "2.3.8"
             }
         },
         "sppull": {
-            "version": "2.2.7",
-            "resolved": "https://registry.npmjs.org/sppull/-/sppull-2.2.7.tgz",
-            "integrity": "sha512-peAdczxF6Vsz6A3O+psKpUXJ6lx1bQKZlt/xudCFKsHViZBfBeEZ1ZkaW0OR2Ne24yHuIJ8NLdejjj7PAlyhcg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/sppull/-/sppull-2.3.0.tgz",
+            "integrity": "sha512-1nXk0PLNbKQG0s5eur9sjgakvcRW7sCJp8LiW/tjxL1dIwb9FMFkM27/xeEy+RpY3UFFmEeuk8vtptFmpXoZng==",
             "requires": {
-                "colors": "1.3.1",
+                "colors": "1.3.2",
                 "mkdirp": "0.5.1",
-                "node-sp-auth-config": "2.5.5",
+                "node-sp-auth-config": "2.5.6",
                 "request": "2.88.0",
                 "sp-request": "2.1.3"
             },
@@ -2203,35 +2204,15 @@
                     "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
                     "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
                 },
-                "chardet": {
-                    "version": "0.5.0",
-                    "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.5.0.tgz",
-                    "integrity": "sha512-9ZTaoBaePSCFvNlNGrsyI8ZVACP2svUtq0DkM7t4K2ClAa96sqOIRjAzDTc8zXzFt1cZR46rRzLTiHFSJ+Qw0g=="
-                },
                 "colors": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.1.tgz",
-                    "integrity": "sha512-jg/vxRmv430jixZrC+La5kMbUWqIg32/JsYNZb94+JEmzceYbWKTsv1OuTp+7EaqiaWRR2tPcykibwCRgclIsw=="
-                },
-                "commander": {
-                    "version": "2.17.1",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-                    "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
+                    "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
                 },
                 "extend": {
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
                     "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-                },
-                "external-editor": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.1.tgz",
-                    "integrity": "sha512-e1neqvSt5pSwQcFnYc6yfGuJD2Q4336cdbHs5VeUO0zTkqPbrHMyw2q1r47fpfLWbvIG8H8A6YO3sck7upTV6Q==",
-                    "requires": {
-                        "chardet": "0.5.0",
-                        "iconv-lite": "0.4.23",
-                        "tmp": "0.0.33"
-                    }
                 },
                 "har-validator": {
                     "version": "5.1.0",
@@ -2242,50 +2223,17 @@
                         "har-schema": "2.0.0"
                     }
                 },
-                "inquirer": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.1.0.tgz",
-                    "integrity": "sha512-f9K2MMx/G/AVmJSaZg2a+GVLRRmTdlGLbwxsibNd6yNTxXujqxPypjCnxnC0y4+Wb/rNY5KyKuq06AO5jrE+7w==",
-                    "requires": {
-                        "ansi-escapes": "3.1.0",
-                        "chalk": "2.4.1",
-                        "cli-cursor": "2.1.0",
-                        "cli-width": "2.2.0",
-                        "external-editor": "3.0.1",
-                        "figures": "2.0.0",
-                        "lodash": "4.17.10",
-                        "mute-stream": "0.0.7",
-                        "run-async": "2.3.0",
-                        "rxjs": "6.2.2",
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "through": "2.3.8"
-                    }
-                },
                 "mime-db": {
-                    "version": "1.35.0",
-                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-                    "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+                    "version": "1.37.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+                    "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
                 },
                 "mime-types": {
-                    "version": "2.1.19",
-                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
-                    "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+                    "version": "2.1.21",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+                    "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
                     "requires": {
-                        "mime-db": "1.35.0"
-                    }
-                },
-                "node-sp-auth-config": {
-                    "version": "2.5.5",
-                    "resolved": "https://registry.npmjs.org/node-sp-auth-config/-/node-sp-auth-config-2.5.5.tgz",
-                    "integrity": "sha512-rDqsSfuVcSW5xBCJ/O+EAvN42Xkt0hcqAFymoRQ4FvOX7rmmCF4O7V+otsocvVx8TYKdWQPXlvRZ4T91IZKusg==",
-                    "requires": {
-                        "colors": "1.3.1",
-                        "commander": "2.17.1",
-                        "cpass": "2.0.4",
-                        "inquirer": "6.1.0",
-                        "mkdirp": "0.5.1",
-                        "node-sp-auth": "2.5.5"
+                        "mime-db": "1.37.0"
                     }
                 },
                 "oauth-sign": {
@@ -2310,7 +2258,7 @@
                         "is-typedarray": "1.0.0",
                         "isstream": "0.1.2",
                         "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.19",
+                        "mime-types": "2.1.21",
                         "oauth-sign": "0.9.0",
                         "performance-now": "2.1.0",
                         "qs": "6.5.2",
@@ -2318,14 +2266,6 @@
                         "tough-cookie": "2.4.3",
                         "tunnel-agent": "0.6.0",
                         "uuid": "3.3.2"
-                    }
-                },
-                "rxjs": {
-                    "version": "6.2.2",
-                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
-                    "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
-                    "requires": {
-                        "tslib": "1.9.3"
                     }
                 },
                 "tough-cookie": {
@@ -2352,7 +2292,7 @@
                 "@types/bluebird": "3.5.20",
                 "@types/core-js": "0.9.46",
                 "@types/lodash": "4.14.108",
-                "@types/node": "6.0.116",
+                "@types/node": "6.14.0",
                 "@types/node-notifier": "0.0.28",
                 "@types/vinyl": "1.2.30",
                 "@types/vinyl-fs": "0.0.28",
@@ -2391,11 +2331,12 @@
             "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
         },
         "stream-combiner": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+            "version": "0.2.2",
+            "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+            "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "0.1.1",
+                "through": "2.3.8"
             }
         },
         "stream-shift": {
@@ -2459,17 +2400,12 @@
             }
         },
         "supports-color": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "requires": {
                 "has-flag": "3.0.0"
             }
-        },
-        "symbol-observable": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-            "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
         },
         "tar": {
             "version": "2.2.1",
@@ -2583,11 +2519,11 @@
             "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
         },
         "url-parse": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
-            "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+            "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
             "requires": {
-                "querystringify": "2.0.0",
+                "querystringify": "2.1.0",
                 "requires-port": "1.0.0"
             }
         },
@@ -2639,7 +2575,7 @@
             "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "requires": {
-                "duplexify": "3.6.0",
+                "duplexify": "3.6.1",
                 "glob-stream": "5.3.5",
                 "graceful-fs": "4.1.11",
                 "gulp-sourcemaps": "1.6.0",
@@ -2684,11 +2620,11 @@
             }
         },
         "vscode": {
-            "version": "1.1.18",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.18.tgz",
-            "integrity": "sha512-SyDw4qFwZ+WthZX7RWp71PNiWLF7VhpM65j2oryY/6jtSORd8qH6J8vclwWZJ6Jvu0EH7JamO2RWNfBfsMR9Zw==",
+            "version": "1.1.21",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.21.tgz",
+            "integrity": "sha512-tJl9eL15ZMm6vzCYYeQ26sSYRuXGMGPsaeIAmG2rOOYRn01jdaDg6I4b9G5Ed6FISdmn6egpKThk4o4om8Ax/A==",
             "requires": {
-                "glob": "7.1.2",
+                "glob": "7.1.3",
                 "gulp-chmod": "2.0.0",
                 "gulp-filter": "5.1.0",
                 "gulp-gunzip": "1.0.0",
@@ -2699,33 +2635,15 @@
                 "mocha": "4.1.0",
                 "request": "2.86.0",
                 "semver": "5.5.0",
-                "source-map-support": "0.5.6",
-                "url-parse": "1.4.1",
+                "source-map-support": "0.5.9",
+                "url-parse": "1.4.3",
                 "vinyl-source-stream": "1.1.2"
             },
             "dependencies": {
-                "commander": {
-                    "version": "2.11.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-                },
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "diff": {
-                    "version": "3.3.1",
-                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-                    "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
-                },
                 "glob": {
-                    "version": "7.1.2",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+                    "version": "7.1.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                     "requires": {
                         "fs.realpath": "1.0.0",
                         "inflight": "1.0.6",
@@ -2734,53 +2652,13 @@
                         "once": "1.4.0",
                         "path-is-absolute": "1.0.1"
                     }
-                },
-                "growl": {
-                    "version": "1.10.3",
-                    "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-                    "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
-                },
-                "has-flag": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-                    "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-                },
-                "mocha": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-                    "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
-                    "requires": {
-                        "browser-stdout": "1.3.0",
-                        "commander": "2.11.0",
-                        "debug": "3.1.0",
-                        "diff": "3.3.1",
-                        "escape-string-regexp": "1.0.5",
-                        "glob": "7.1.2",
-                        "growl": "1.10.3",
-                        "he": "1.1.1",
-                        "mkdirp": "0.5.1",
-                        "supports-color": "4.4.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                },
-                "supports-color": {
-                    "version": "4.4.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-                    "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-                    "requires": {
-                        "has-flag": "2.0.0"
-                    }
                 }
             }
         },
         "vscode-uri": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.5.tgz",
-            "integrity": "sha1-O4majvccN/MFTXm9vdoxx7828g0="
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.6.tgz",
+            "integrity": "sha512-sLI2L0uGov3wKVb9EB+vIQBl9tVP90nqRvxSoJ35vI3NjxE8jfsE5DSOhWgSunHSZmKS4OCi2jrtfxK7uyp2ww=="
         },
         "which": {
             "version": "1.3.0",
@@ -2809,9 +2687,9 @@
             "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         },
         "yauzl": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.2.tgz",
-            "integrity": "sha1-T7G8euH8L1cDe1SvasyP4QMcW3c=",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "requires": {
                 "buffer-crc32": "0.2.13",
                 "fd-slicer": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "o365",
         "ide"
     ],
-    "version": "1.3.2",
+    "version": "1.3.3",
     "publisher": "SiteGo",
     "icon": "assets/SiteGoLogo.png",
     "galleryBanner": {
@@ -39,7 +39,18 @@
     ],
     "activationEvents": [
         "workspaceContains:SPGo.json",
-        "onCommand:spgo.configureWorkspace"
+        "onCommand:spgo.checkOutFile",
+        "onCommand:spgo.compareFileWithServer",
+        "onCommand:spgo.configureWorkspace",
+        "onCommand:spgo.deleteFile",
+        "onCommand:spgo.discardCheckOut",
+        "onCommand:spgo.populateWorkspace",
+        "onCommand:spgo.publishWorkspace",
+        "onCommand:spgo.publishMajor",
+        "onCommand:spgo.publishMinor",
+        "onCommand:spgo.reloadConfiguration",
+        "onCommand:spgo.resetCredentials",
+        "onCommand:spgo.retrieveFolder"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -179,20 +190,20 @@
     },
     "devDependencies": {
         "@types/mocha": "^2.2.32",
-        "@types/node": "^6.0.116",
+        "@types/node": "^6.14.0",
         "mocha": "^4.0.1",
         "typescript": "2.5.0"
     },
     "dependencies": {
-        "cpass": "^2.0.4",
+        "cpass": "^2.0.5",
         "fs-extra": "^4.0.3",
-        "node-sp-auth": "^2.5.5",
+        "node-sp-auth": "^2.5.6",
         "parse-glob": "^3.0.4",
         "path": "^0.12.7",
         "sp-request": "^2.1.3",
-        "sppull": "^2.2.7",
+        "sppull": "^2.3.0",
         "spsave": "^3.1.5",
-        "vscode": "^1.1.18",
-        "vscode-uri": "^1.0.5"
+        "vscode": "^1.1.21",
+        "vscode-uri": "^1.0.6"
     }
 }

--- a/src/appManager.ts
+++ b/src/appManager.ts
@@ -1,4 +1,6 @@
 'use strict';
+import * as path from 'path';
+import * as fs from 'fs-extra';
 import * as vscode from 'vscode';
 
 import { IConfig } from './spgo';
@@ -7,6 +9,7 @@ import { Constants } from './constants';
 import { IAppManager, ICredential } from './spgo';
 import { CredentialDao } from './dao/credentialDao';
 import initializeConfiguration from './dao/configurationDao';
+import configureWorkspace from './command/configureWorkspace';
 
 export class AppManager implements IAppManager {
     public config : IConfig;
@@ -18,19 +21,57 @@ export class AppManager implements IAppManager {
         this.credentials = null;
         this.outputChannel = vscode.window.createOutputChannel(Constants.OUTPUT_CHANNEL_NAME);
         this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 5);
+    }
 
-        //initialize Configuration file
-        initializeConfiguration(this).then(()=> {
-            //stored credentials?
-            if(this.config.storeCredentials){
-                this.credentials = CredentialDao.getCredentials(this.config.sharePointSiteUrl);
+    public initialize(){
+        return new Promise((resolve, reject) => {
+            let configFilePath : string = vscode.workspace.rootPath + path.sep + Constants.CONFIG_FILE_NAME;
+
+            if( this.config === undefined){
+                //initialize Configuration file
+                fs.stat(configFilePath, (err) => {
+                    // config file exists!
+                    if( err == null){
+                        initializeConfiguration(vscode.window.spgo).then(()=> {
+                            //stored credentials?
+                            if(vscode.window.spgo.config.storeCredentials){
+                                vscode.window.spgo.credentials = CredentialDao.getCredentials(this.config.sharePointSiteUrl);
+                            }
+                            vscode.window.spgo.statusBarItem.text = 'SPGo enabled';
+                            vscode.window.spgo.statusBarItem.show();
+
+                            resolve();
+
+                        }).catch(err => {
+                            Logger.showError('SPGo: Missing Configuration');
+                            Logger.outputError(err);
+                            reject();
+                        });
+                    }
+                    else{
+                        // run config
+                        vscode.window.showWarningMessage('SPGo has not been configured for this project. Would you like to configure your workspace now?', Constants.OPTIONS_YES, Constants.OPTIONS_NO)
+                        .then(result => {
+                            if( result == Constants.OPTIONS_NO){
+                                Logger.outputMessage('SPGo initialization cancelled by user.');
+                                reject();
+                            }
+                            else{
+                                configureWorkspace()
+                                    .then(() => 
+                                    {
+                                        vscode.window.spgo.statusBarItem.text = 'SPGo enabled';
+                                        vscode.window.spgo.statusBarItem.show();
+                                        resolve();
+                                    });
+                            }
+                        });
+                    }
+                });
             }
-            this.statusBarItem.text = 'SPGo enabled';
-        }).catch(err => {
-            Logger.showError('SPGo: Missing Configuration');
-            Logger.outputError(err);
+            else{
+                resolve();
+            }
         });
-        
-        this.statusBarItem.show();
     }
 }

--- a/src/command/checkOutFile.ts
+++ b/src/command/checkOutFile.ts
@@ -4,7 +4,6 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as vscode from 'vscode';
 
-
 import { Logger } from '../util/logger';
 import { Constants } from './../constants';
 import { UiHelper } from './../util/uiHelper';
@@ -25,10 +24,8 @@ export default function checkOutFile(fileUri: vscode.Uri) : Thenable<any> {
             let fileName : string = FileHelper.getFileName(fileUri.fsPath);
             let fileService : SPFileService = new SPFileService();
 
-            Logger.outputMessage(`Checking out File:  ${fileUri.fsPath}`, vscode.window.spgo.outputChannel);
-
             return UiHelper.showStatusBarProgress(`Checking out File:  ${fileName}`,
-                AuthenticationService.verifyCredentials(vscode.window.spgo, fileUri)
+                 AuthenticationService.verifyCredentials(vscode.window.spgo, fileUri)
                     .then((filePath) => fileService.checkoutFile(filePath))
                     .then(() => downloadFileAndCompare(fileUri, downloadPath))
                     .catch(err => ErrorHelper.handleError(err))

--- a/src/command/configureWorkspace.ts
+++ b/src/command/configureWorkspace.ts
@@ -19,7 +19,7 @@ export default function configureWorkspace() {
         
     
     function getSharePointSiteUrl() {
-        return new Promise(function (resolve, reject) {
+        return new Promise((resolve, reject) => {
             initializeConfiguration().then(config => {
                 let options: vscode.InputBoxOptions = {
                     ignoreFocusOut: true,

--- a/src/command/configureWorkspace.ts
+++ b/src/command/configureWorkspace.ts
@@ -8,7 +8,7 @@ import { Constants } from './../constants';
 import { UrlHelper } from '../util/urlHelper';
 import initializeConfiguration from './../dao/configurationDao';
 
-export default function configureWorkspace() {
+export default function configureWorkspace() : Promise<any> {
     vscode.window.spgo.statusBarItem.text = 'SPGo: Show Menu';
 
     return getSharePointSiteUrl()

--- a/src/command/deleteFile.ts
+++ b/src/command/deleteFile.ts
@@ -21,12 +21,12 @@ export default function deleteFile(fileUri: vscode.Uri) : Thenable<any> {
         if( fileUri.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
             let fileName : string = FileHelper.getFileName(fileUri.fsPath);
             let fileService : SPFileService = new SPFileService();
-    
-            Logger.outputMessage(`Deleting file  ${fileUri.fsPath} from server.`, vscode.window.spgo.outputChannel);
             
             return UiHelper.showStatusBarProgress(`Deleting ${fileName}`,
                 AuthenticationService.verifyCredentials(vscode.window.spgo, fileUri)
                     .then((fileUri) => {
+                        Logger.outputMessage(`Deleting file  ${fileUri.fsPath} from server.`, vscode.window.spgo.outputChannel);
+
                         return vscode.window.showWarningMessage(`Are you sure you want to delete ${fileName} from the server?`, Constants.OPTIONS_YES, Constants.OPTIONS_NO)
                             .then(result => {
                                 if( result == Constants.OPTIONS_YES){

--- a/src/command/discardCheckOut.ts
+++ b/src/command/discardCheckOut.ts
@@ -21,8 +21,6 @@ export default function discardCheckOut(fileUri: vscode.Uri) : Thenable<any> {
         if( fileUri.fsPath.includes(vscode.window.spgo.config.workspaceRoot)){
             let fileName : string = FileHelper.getFileName(fileUri.fsPath);
             let fileService : SPFileService = new SPFileService();
-
-            Logger.outputMessage(`Discarding Check out for File:  ${fileUri.fsPath}`, vscode.window.spgo.outputChannel);
             
             return UiHelper.showStatusBarProgress(`Discarding Check out for:  ${fileName}`,
                 AuthenticationService.verifyCredentials(vscode.window.spgo, fileUri)

--- a/src/command/getCurrentFileInformation.ts
+++ b/src/command/getCurrentFileInformation.ts
@@ -11,7 +11,6 @@ import {AuthenticationService} from './../service/authenticationService';
 export default function saveFile(textDocument: vscode.TextDocument) : Thenable<any> { 
 
     if( textDocument.fileName.includes(vscode.window.spgo.config.workspaceRoot)){
-        Logger.outputMessage(`Getting file information for:  ${textDocument.fileName}`, vscode.window.spgo.outputChannel);
         let fileService : SPFileService = new SPFileService();
 
         return UiHelper.showStatusBarProgress('',

--- a/src/command/populateWorkspace.ts
+++ b/src/command/populateWorkspace.ts
@@ -21,7 +21,7 @@ export default function populateWorkspace() : Thenable<any> {
 
     function downloadFiles() : Thenable<any> {
         
-        return new Promise(function (resolve, reject) {
+        return new Promise((resolve, reject) => {
             let downloads : Promise<any>[] = [];
 
             if(vscode.window.spgo.config.remoteFolders){
@@ -29,7 +29,7 @@ export default function populateWorkspace() : Thenable<any> {
                     downloads.push(fileService.downloadFiles(folder));
                 }
                 Promise.all(downloads)
-                    .then(function(){
+                    .then(() => {
                         Logger.outputMessage(`file synchronization complete.`, vscode.window.spgo.outputChannel);
                         resolve();
                     })

--- a/src/command/populateWorkspace.ts
+++ b/src/command/populateWorkspace.ts
@@ -9,8 +9,6 @@ import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationService';
 
 export default function populateWorkspace() : Thenable<any> {
-        
-    Logger.outputMessage('Starting File Synchronization...', vscode.window.spgo.outputChannel);
     let fileService : SPFileService = new SPFileService();
 
     return UiHelper.showStatusBarProgress('Populating workspace',
@@ -23,6 +21,8 @@ export default function populateWorkspace() : Thenable<any> {
         
         return new Promise((resolve, reject) => {
             let downloads : Promise<any>[] = [];
+            
+            Logger.outputMessage('Starting File Synchronization...', vscode.window.spgo.outputChannel);
 
             if(vscode.window.spgo.config.remoteFolders){
                 for (let folder of vscode.window.spgo.config.remoteFolders) {

--- a/src/command/publishFile.ts
+++ b/src/command/publishFile.ts
@@ -42,8 +42,8 @@ export default function publishFile(fileUri: vscode.Uri, publishingScope : strin
         return UiHelper.showStatusBarProgress(`Publishing ${publishingScope} file version:  ${fileName}`,
             AuthenticationService.verifyCredentials(vscode.window.spgo, publishingInfo)
                 .then((publishingInfo) => UiHelper.getPublishingMessage(publishingInfo))
-                .then((publishingInfo) => fileService.uploadFileToServer(publishingInfo, publishingScope))
-                .then(function(){
+                .then((publishingInfo) => fileService.uploadFilesToServer(publishingInfo))
+                .then(() => {
                     Logger.outputMessage('File publish complete.', vscode.window.spgo.outputChannel);
                 })
                 .catch(err => ErrorHelper.handleError(err))

--- a/src/command/publishWorkspace.ts
+++ b/src/command/publishWorkspace.ts
@@ -23,6 +23,7 @@ export default function publishWorkspace() : Thenable<any> {
         AuthenticationService.verifyCredentials(vscode.window.spgo, publishingInfo)
             .then((publishingInfo) => UiHelper.getPublishingMessage(publishingInfo))
             .then((publishingInfo) => fileService.uploadFilesToServer(publishingInfo))
+            .then(()=>{Logger.outputMessage('Workspace Publish complete.', vscode.window.spgo.outputChannel)})
             .catch(err => ErrorHelper.handleError(err))
     );
 }

--- a/src/command/retrieveFolder.ts
+++ b/src/command/retrieveFolder.ts
@@ -8,7 +8,6 @@ import {SPFileService} from './../service/spFileService';
 import {AuthenticationService} from './../service/authenticationService';
 
 export default function retrieveFolder() : Thenable<any> {
-    Logger.outputMessage('Starting folder download...', vscode.window.spgo.outputChannel);
     let fileService : SPFileService = new SPFileService();
 
     return UiHelper.showStatusBarProgress('Downloading files',
@@ -18,6 +17,8 @@ export default function retrieveFolder() : Thenable<any> {
     );
 
     function downloadFiles() : Thenable<any> {
+        
+        Logger.outputMessage('Starting folder download...', vscode.window.spgo.outputChannel);
         
         return new Promise((resolve, reject) => {
             let options: vscode.InputBoxOptions = {

--- a/src/command/retrieveFolder.ts
+++ b/src/command/retrieveFolder.ts
@@ -19,7 +19,7 @@ export default function retrieveFolder() : Thenable<any> {
 
     function downloadFiles() : Thenable<any> {
         
-        return new Promise(function (resolve, reject) {
+        return new Promise((resolve, reject) => {
             let options: vscode.InputBoxOptions = {
                 ignoreFocusOut: true,
                 placeHolder: '/site/relative/path/to/folder',
@@ -27,7 +27,8 @@ export default function retrieveFolder() : Thenable<any> {
             };
             vscode.window.showInputBox(options).then(result => {
                 fileService.downloadFiles(result)
-                    .then(function() {
+                    .then(() => {
+                        Logger.outputMessage(`Retrieve folder success.`);
                         resolve();
                     }).catch(err => {
                         reject(err);

--- a/src/command/saveFile.ts
+++ b/src/command/saveFile.ts
@@ -21,8 +21,6 @@ export default function saveFile(fileUri: vscode.Uri) : Thenable<any> {
             scope : null,
             message : vscode.window.spgo.config.checkInMessage || Constants.PUBLISHING_DEFAULT_MESSAGE
         }
-        
-        Logger.outputMessage(`Saving file:  ${fileUri.fsPath}`, vscode.window.spgo.outputChannel);
 
         return UiHelper.showStatusBarProgress(`Saving file:  ${fileName}`,
             AuthenticationService.verifyCredentials(vscode.window.spgo, publishAction)

--- a/src/command/saveFile.ts
+++ b/src/command/saveFile.ts
@@ -26,7 +26,10 @@ export default function saveFile(fileUri: vscode.Uri) : Thenable<any> {
 
         return UiHelper.showStatusBarProgress(`Saving file:  ${fileName}`,
             AuthenticationService.verifyCredentials(vscode.window.spgo, publishAction)
-                .then((publishAction) => fileService.uploadFileToServer(publishAction)) 
+                .then((publishAction) => fileService.uploadFilesToServer(publishAction)) 
+                .then(() => {
+                    Logger.outputMessage(`File saved successfully`);
+                })
                 .catch(err => ErrorHelper.handleError(err))
         );
     }

--- a/src/dao/configurationDao.ts
+++ b/src/dao/configurationDao.ts
@@ -3,11 +3,11 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as vscode from 'vscode';
 
-import { IConfig } from './../spgo';
+import {IConfig} from './../spgo';
 import {IAppManager} from './../spgo';
 import {Logger} from '../util/logger';
 import {Constants} from './../constants';
-import { UrlHelper } from '../util/urlHelper';
+import {UrlHelper} from '../util/urlHelper';
 
 export default function initializeConfiguration(appManager?: IAppManager): Promise<IConfig> {
 	return new Promise((resolve, reject) => {
@@ -41,7 +41,9 @@ export default function initializeConfiguration(appManager?: IAppManager): Promi
 						self.config.sourceDirectory = 'src';
 					}
 					//Remove the trailing slash if a user enters one, e.g. https://tennant.sharepoint.com/sites/mysite/
-					self.config.sharePointSiteUrl = UrlHelper.removeTrailingSlash(self.config.sharePointSiteUrl);
+					if(self.config.sharePointSiteUrl !== undefined){
+						self.config.sharePointSiteUrl = UrlHelper.removeTrailingSlash(self.config.sharePointSiteUrl);
+					}
 		
 					resolve(self.config);
 				} 

--- a/src/dao/configurationDao.ts
+++ b/src/dao/configurationDao.ts
@@ -10,7 +10,7 @@ import {Constants} from './../constants';
 import { UrlHelper } from '../util/urlHelper';
 
 export default function initializeConfiguration(appManager?: IAppManager): Promise<IConfig> {
-	return new Promise(function (resolve, reject) {
+	return new Promise((resolve, reject) => {
 		var self: IAppManager = appManager || vscode.window.spgo;
 		try{
 			

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,10 +105,10 @@ export function activate(context: vscode.ExtensionContext): any {
      //Download the contents of a SharePoint folder (and subfolders) to your local workspace.
      context.subscriptions.push(vscode.commands.registerCommand('spgo.reloadConfiguration', () => {
         initializeConfiguration(vscode.window.spgo)
-            .then(function() {
+            .then(() => {
                 Logger.updateStatusBar('Configuration file reloaded', 5);
             })
-            .catch(function(err : SPGo.IError) {
+            .catch((err : SPGo.IError) => {
                 Logger.showError(err.message, err);
             });
     }));
@@ -138,10 +138,10 @@ export function activate(context: vscode.ExtensionContext): any {
             //is this an update to the config? Reload the config.
             else if(textDocument.fileName.endsWith(path.sep + Constants.CONFIG_FILE_NAME)){
                 initializeConfiguration(vscode.window.spgo)
-                    .then(function() {
+                    .then(() => {
                         Logger.updateStatusBar('Configuration file reloaded', 5);
                     })
-                    .catch(function(err : SPGo.IError) {
+                    .catch((err : SPGo.IError) => {
                         Logger.showError(err.message, err);
                     });
             }

--- a/src/gateway/spFileGateway.ts
+++ b/src/gateway/spFileGateway.ts
@@ -66,7 +66,7 @@ export class SPFileGateway{
             .then(()=>{
                 return new Promise((resolve,reject) => {
                     sppull(context, fileOptions)
-                        .then((downloadResults : []) => {
+                        .then((downloadResults : Array<any>) => {
                             if( fileOptions.strictObjects && fileOptions.strictObjects.length > 0){
                                 Logger.outputMessage(`Successfully downloaded ${fileOptions.strictObjects[0]} files to: ${fileOptions.dlRootFolder}`, vscode.window.spgo.outputChannel);
                             }
@@ -83,7 +83,7 @@ export class SPFileGateway{
             .then(()=>{
                 return new Promise((resolve,reject) => {
                     sppull(context, fileOptions)
-                        .then((downloadResults : []) => {
+                        .then((downloadResults : Array<any>) => {
                             Logger.outputMessage(`Successfully downloaded ${downloadResults.length} files to: ${vscode.window.spgo.config.sourceDirectory + remoteFolder}`, vscode.window.spgo.outputChannel);
                             resolve(downloadResults);
                         })
@@ -156,7 +156,5 @@ export class SPFileGateway{
                         .catch((err) => reject(err));
                 });
             });
-        
     }
-
 }

--- a/src/service/authenticationService.ts
+++ b/src/service/authenticationService.ts
@@ -1,10 +1,10 @@
 'use strict';
 import * as vscode from 'vscode';
 
-import { IAppManager } from './../spgo';
+import { IAppManager } from '../spgo';
 import { Logger } from '../util/logger';
 import { CredentialDao } from '../dao/credentialDao';
-import { RequestHelper } from './../util/requestHelper'
+import { RequestHelper } from '../util/requestHelper'
 
 export class AuthenticationService{
 	
@@ -37,7 +37,7 @@ export class AuthenticationService{
 	
 		// take user's SharePoint username input
 		function getUserName(appManager) {
-			return new Promise(function (resolve, reject) {
+			return new Promise((resolve, reject) => {
 				let options: vscode.InputBoxOptions = {
 					ignoreFocusOut: true,
 					placeHolder: 'user@domain.com [or domain\\user]',
@@ -57,7 +57,7 @@ export class AuthenticationService{
 	
 		// take user's password input
 		function getPassword(appManager) {
-			return new Promise(function (resolve, reject) {
+			return new Promise((resolve, reject) => {
 				let options: vscode.InputBoxOptions = {
 					ignoreFocusOut: true,
 					password: true,
@@ -65,7 +65,7 @@ export class AuthenticationService{
 					placeHolder: 'password',
 					prompt: 'Please enter your SharePoint password',
 				};
-				return vscode.window.showInputBox(options).then(function (result: string) {
+				return vscode.window.showInputBox(options).then((result: string) => {
 					appManager.credentials.password = result || appManager.credentials.password || '';
 					if (!appManager.credentials.password) { 
 						reject('No Password'); 
@@ -78,12 +78,12 @@ export class AuthenticationService{
 	
 		// Test the new credential set to make sure it is valid
 		function verify(appManager){
-			return new Promise(function(resolve, reject) {
+			return new Promise((resolve, reject) => {
 				
 				let spr = RequestHelper.createRequest(appManager);
 
 				spr.requestDigest(vscode.window.spgo.config.sharePointSiteUrl)
-					.then(function(){ //response => {
+					.then(() => { //response => {
 						//store credentials?
 						if(appManager.config.storeCredentials){
 							CredentialDao.setCredentials(vscode.window.spgo.config.sharePointSiteUrl, appManager.credentials);
@@ -99,7 +99,7 @@ export class AuthenticationService{
 
 		// Authtntication was successful, process the command provided by the caller.
 		function processNextCommand(appManager) {			
-			return new Promise(function (resolve, reject) {
+			return new Promise((resolve, reject) => {
 				if(appManager && appManager.credentials){
 					resolve(payload);
 				}

--- a/src/service/spFileService.ts
+++ b/src/service/spFileService.ts
@@ -13,6 +13,7 @@ import {RequestHelper} from './../util/requestHelper'
 import {SPFileGateway} from './../gateway/spFileGateway';
 import { DownloadFileOptionsFactory } from '../factory/downloadFileOptionsFactory';
 import { ICoreOptions, FileOptions } from 'spsave';
+import { Logger } from '../util/logger';
 
 export class SPFileService{
     constructor (){}
@@ -80,6 +81,8 @@ export class SPFileService{
         let fileGateway : SPFileGateway = new SPFileGateway();
         let spr : ISPRequest = RequestHelper.createRequest(vscode.window.spgo);
         
+        Logger.outputMessage(`Getting file information for:  ${textDocument.fileName}`, vscode.window.spgo.outputChannel);
+        
         return fileGateway.getFileInformation(fileUri, spr);
     }
 
@@ -87,6 +90,8 @@ export class SPFileService{
         let fileUri : Uri = UrlHelper.getServerRelativeFileUri(filePath.fsPath);
         let fileGateway : SPFileGateway = new SPFileGateway();
         let spr : ISPRequest = RequestHelper.createRequest(vscode.window.spgo);
+        
+        Logger.outputMessage(`Checking out File:  ${fileUri.fsPath}`, vscode.window.spgo.outputChannel);
         
         return fileGateway.checkOutFile(fileUri, spr);
     }
@@ -96,6 +101,8 @@ export class SPFileService{
         let fileGateway : SPFileGateway = new SPFileGateway();
         let spr : ISPRequest = RequestHelper.createRequest(vscode.window.spgo);
         
+        Logger.outputMessage(`Discarding Check out for File:  ${fileUri.fsPath}`, vscode.window.spgo.outputChannel);
+
         return fileGateway.undoCheckOutFile(fileUri, spr);
     }
     
@@ -123,7 +130,9 @@ export class SPFileService{
             base : localFilePath,
             folder: '/'
         };
-
+        
+        Logger.outputMessage(`Saving file:  ${publishingInfo.contentUri}`, vscode.window.spgo.outputChannel);
+        
         return fileGateway.uploadFiles(coreOptions, credentials, fileOptions);
     }
 

--- a/src/spgo.ts
+++ b/src/spgo.ts
@@ -12,6 +12,8 @@ export interface IAppManager{
     config? : IConfig;
     outputChannel: vscode.OutputChannel;
     statusBarItem: vscode.StatusBarItem;
+
+    initialize() : Promise<any>;
 }
 
 export interface ICredential{

--- a/src/util/requestHelper.ts
+++ b/src/util/requestHelper.ts
@@ -1,4 +1,6 @@
 'use strict';
+
+import * as vscode from 'vscode';
 import * as spRequest from 'sp-request';
 import {
     IUserCredentials,
@@ -18,7 +20,7 @@ export class RequestHelper {
                 let credentials : IAdfsUserCredentials = {
                     password: appManager.credentials.password,
                     username: appManager.credentials.username,
-                    relyingParty: appManager.config.authenticationDetails.relayingParty,
+                    relyingParty: appManager.config.authenticationDetails.relyingParty,
                     adfsUrl: appManager.config.authenticationDetails.adfsUrl
                 };
                 
@@ -66,17 +68,11 @@ export class RequestHelper {
         }
     }
 
-    static createHeaders(appManager : IAppManager, digest : string, additionalHeaders? : any) : any { 
+    static createAuthHeaders(appManager : IAppManager, digest : string, additionalHeaders? : any) : any { 
 
         let headers : any = additionalHeaders || {};
 
-        if( Constants.SECURITY_NTLM == appManager.config.authenticationType){
-            process.env['_sp_request_headers'] = JSON.stringify({
-                'X-FORMS_BASED_AUTH_ACCEPTED': 'f'
-            });
-            headers['X-RequestDigest'] = digest
-        }
-        else if( Constants.SECURITY_DIGEST == appManager.config.authenticationType){
+        if( Constants.SECURITY_NTLM == appManager.config.authenticationType || Constants.SECURITY_DIGEST == appManager.config.authenticationType){
             headers['X-RequestDigest'] = digest
         }
 
@@ -84,12 +80,36 @@ export class RequestHelper {
     }
 
     static createRequest(appManager : IAppManager) : spRequest.ISPRequest {
+        if( Constants.SECURITY_NTLM == appManager.config.authenticationType){
+            process.env['_sp_request_headers'] = JSON.stringify({
+                'X-FORMS_BASED_AUTH_ACCEPTED': 'f'
+            });
+        }
+
         return spRequest.create(this.createCredentials(appManager));
     }
 
-    static setNtlmHeader(){
-        process.env['_sp_request_headers'] = JSON.stringify({
-            'X-FORMS_BASED_AUTH_ACCEPTED': 'f'
+    // static setNtlmHeader(){
+    //     let appManager : IAppManager = vscode.window.spgo;
+
+    //     if( Constants.SECURITY_NTLM == appManager.config.authenticationType){
+    //         process.env['_sp_request_headers'] = JSON.stringify({
+    //             'X-FORMS_BASED_AUTH_ACCEPTED': 'f'
+    //         });
+    //     }
+    // }
+
+    static setNtlmHeader(payload? : any){
+        return new Promise((resolve) => {
+            let appManager : IAppManager = vscode.window.spgo;
+
+            if( Constants.SECURITY_NTLM == appManager.config.authenticationType){
+                process.env['_sp_request_headers'] = JSON.stringify({
+                    'X-FORMS_BASED_AUTH_ACCEPTED': 'f'
+                });
+            }
+
+            resolve(payload);
         });
     }
 }

--- a/src/util/requestHelper.ts
+++ b/src/util/requestHelper.ts
@@ -64,7 +64,6 @@ export class RequestHelper {
                 
                 return credentials;
             }
-
         }
     }
 
@@ -88,16 +87,6 @@ export class RequestHelper {
 
         return spRequest.create(this.createCredentials(appManager));
     }
-
-    // static setNtlmHeader(){
-    //     let appManager : IAppManager = vscode.window.spgo;
-
-    //     if( Constants.SECURITY_NTLM == appManager.config.authenticationType){
-    //         process.env['_sp_request_headers'] = JSON.stringify({
-    //             'X-FORMS_BASED_AUTH_ACCEPTED': 'f'
-    //         });
-    //     }
-    // }
 
     static setNtlmHeader(payload? : any){
         return new Promise((resolve) => {

--- a/test/converter/globToCamlConverter.test.ts
+++ b/test/converter/globToCamlConverter.test.ts
@@ -28,7 +28,7 @@ describe("Convert Glob to Caml Tests", () => {
     
     let globRoot : string = 'path/'
     
-    beforeEach(function() {
+    beforeEach(() => {
         vscode.window.spgo = new AppManager();
         vscode.window.spgo.config = {
             authenticationType : Constants.SECURITY_DIGEST,

--- a/test/factory/downloadFileOptionsFactory.test.ts
+++ b/test/factory/downloadFileOptionsFactory.test.ts
@@ -13,7 +13,7 @@ describe("Convert Glob to Caml Tests", () => {
     
     let globRoot : string = 'path/'
     
-    beforeEach(function() {
+    beforeEach(() => {
         vscode.window.spgo = new AppManager();
         vscode.window.spgo.config = {
             authenticationType : Constants.SECURITY_DIGEST,


### PR DESCRIPTION
## 1.3.3 - 2018-10-30
### Added
- Running any SPGo-based command will now activate SPGo, or prompt you to configure a local workspace if no `spgo.json` config file is present. Great UX enhancement idea via email request.
### Fixed
- [This Issue](https://github.com/readysitego/spgo/issues/64) where SPGo *did not* consistently apply the correct auth headers for NTLM + www Auth, which *did* consistently annoying users.
- [This Other Issue](https://github.com/readysitego/spgo/issues/63) where SPGo was unable to download files outside of folders. Really I didn't do much outside of type "npm update", as the heavy lifting was done by [@koltyakov](https://github.com/koltyakov). THANKS!
- [This Other, Other, Issue](https://github.com/readysitego/spgo/issues/60) where json files without json extensions did not properly download. Again, thanks to [@koltyakov](https://github.com/koltyakov) for providing a fix via his great [sppull](https://github.com/koltyakov/sppull) library!